### PR TITLE
fix(TypeError: functools.partial(<function inject_router at 0x74595c2…

### DIFF
--- a/src/maxo/integrations/dishka.py
+++ b/src/maxo/integrations/dishka.py
@@ -91,8 +91,10 @@ def setup_dishka(
     )
 
     if auto_inject:
-        callback = partial(inject_router, router=dispatcher)
-        dispatcher.before_startup.handler(callback)
+        def _auto_inject(**_kwargs: Any) -> None:
+            inject_router(dispatcher)
+
+        dispatcher.before_startup.handler(_auto_inject)
 
 
 def inject_router(router: BaseRouter) -> None:


### PR DESCRIPTION
…dfec0>, router=<Router 'Dispatcher'>): убрал partial, который вызывал ошибку

# Описание

Убрал partial, вместо него добавил обычную функцию. Ранее это вызывало ошибку TypeError: functools.partial(<function inject_router at 0x74595c2dfec0>, router=<Router 'Dispatcher'>) is not a module, class, method, or function. get_type_hints ругался на него, потому что partial это callable.

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [ ] Документация (опечатки, примеры кода или любые другие обновления документации)
- [x] Исправление бага (некритическое изменение, которое устраняет проблему)
- [ ] Новый функционал (некритическое изменение, добавляющее функциональность)
- [ ] Критические изменения (исправление или функционал, из-за которого существующая функциональность не будет работать должным образом)
- [ ] Это изменение требует обновления документации

# Как это было протестировано?

На практике столкнулся с проблемой и исправил ее

Описание

**Тестовая конфигурация**:
* Операционная система: win10
* Версия Python: 3.12.7

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я внес соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
