### PR TITLE
fix(calendar_kbd): убрал пустой текст и payload в календаре

### DIFF
--- a/src/maxo/dialogs/widgets/kbd/calendar_kbd.py
+++ b/src/maxo/dialogs/widgets/kbd/calendar_kbd.py
@@ -60,7 +60,7 @@ BEARING_DATE = date(2018, 1, 1)
 
 
 def empty_button():
-    return CallbackKeyboardButton(text="-", payload="-")
+    return CallbackKeyboardButton(text="⠀", payload="⠀")
 
 
 class CalendarScope(Enum):
@@ -285,7 +285,7 @@ class CalendarDaysView(CalendarScopeView):
             header.append(
                 CallbackKeyboardButton(
                     text=await self.weekday_text.render_text(data, manager),
-                    payload="-",
+                    payload="⠀",
                 ),
             )
         return header


### PR DESCRIPTION
# Описание

Починил calendar_kbd.py у которого был пустой payload и текст. Это вызывало ошибку у max api.

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [ ] Документация (опечатки, примеры кода или любые другие обновления документации)
- [x] Исправление бага (некритическое изменение, которое устраняет проблему)
- [ ] Новый функционал (некритическое изменение, добавляющее функциональность)
- [ ] Критические изменения (исправление или функционал, из-за которого существующая функциональность не будет работать должным образом)
- [ ] Это изменение требует обновления документации

# Как это было протестировано?

Тестировал в проекте

Описание

**Тестовая конфигурация**: default
* Операционная система: MacOS
* Версия Python: 3.12

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я внес соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
