### PR TITLE
Фикс диалоговских`CallableObject`, фикс сохранения аттачментов в стэке

### DIFF
--- a/examples/dialogs_form.py
+++ b/examples/dialogs_form.py
@@ -12,11 +12,10 @@ from maxo.dialogs import (
     Window,
     setup_dialogs,
 )
-from maxo.dialogs.widgets.input import MessageInput
+from maxo.dialogs.widgets.input import ManagedTextInput, MessageInput, TextInput
 from maxo.dialogs.widgets.kbd import Back, Button, Row, Select, SwitchTo
 from maxo.dialogs.widgets.media import StaticMedia
 from maxo.dialogs.widgets.text import Const, Format, Multi
-from maxo.enums import AttachmentType
 from maxo.fsm import State, StatesGroup
 from maxo.fsm.key_builder import DefaultKeyBuilder
 from maxo.routing.filters import CommandStart
@@ -48,13 +47,15 @@ async def get_data(dialog_manager: DialogManager, **__: Any) -> dict[str, Any]:
 
 async def name_handler(
     message: MessageCreated,
-    message_input: MessageInput,
+    text_input: ManagedTextInput[str],
     dialog_manager: DialogManager,
+    name: str,
 ) -> None:
     if dialog_manager.is_preview():
         await dialog_manager.next()
         return
-    dialog_manager.dialog_data["name"] = message.message.body.text
+
+    dialog_manager.dialog_data["name"] = name
 
     facade: MessageCreatedFacade = dialog_manager.middleware_data["facade"]
     await facade.answer_text(f"Привет, {message.message.body.text}")
@@ -101,7 +102,7 @@ dialog = Dialog(
         Const("Привет! Представься, пожалуйста:"),
         StaticMedia(path=BASE_DIR / "files" / "watermelon.jpg"),
         StaticMedia(path=BASE_DIR / "files" / "naked-watermelon.png"),
-        MessageInput(name_handler, content_types=AttachmentType.TEXT),
+        TextInput(id="name_handler", on_success=name_handler),
         MessageInput(other_type_handler),
         state=DialogSG.greeting,
     ),

--- a/src/maxo/dialogs/context/storage.py
+++ b/src/maxo/dialogs/context/storage.py
@@ -8,6 +8,10 @@ from maxo.enums import ChatType
 from maxo.fsm import State, StatesGroup
 from maxo.fsm.key_builder import StorageKey
 from maxo.fsm.storages.base import BaseEventIsolation, BaseStorage
+from maxo.serialization import create_retort
+from maxo.types import Attachments
+
+retort = create_retort()
 
 
 class StorageProxy:
@@ -63,6 +67,13 @@ class StorageProxy:
         access_settings = self._default_access_settings(stack_id)
         if not data:
             return Stack(_id=fixed_stack_id, access_settings=access_settings)
+
+        if "last_attachments" in data:
+            data["last_attachments"] = retort.load(
+                data["last_attachments"],
+                list[Attachments],
+            )
+
         return Stack(access_settings=access_settings, **data)
 
     async def save_context(self, context: Context | None) -> None:
@@ -104,6 +115,10 @@ class StorageProxy:
                 "intents": stack.intents,
                 "last_message_id": stack.last_message_id,
                 "last_sequence_id": stack.last_sequence_id,
+                "last_attachments": retort.dump(
+                    stack.last_attachments,
+                    list[Attachments],
+                ),
             }
             await self.storage.set_data(
                 key=self._stack_key(stack.id),

--- a/src/maxo/dialogs/manager/message_manager.py
+++ b/src/maxo/dialogs/manager/message_manager.py
@@ -169,7 +169,7 @@ class MessageManager(MessageManagerProtocol):
         bot: Bot,
         old_message: OldMessage | None,
     ) -> Message | None:
-        if not old_message:
+        if not old_message or old_message.keyboard is None:
             return None
         logger.debug("remove_inline_kbd in %s", old_message.recipient)
         try:

--- a/src/maxo/dialogs/tools/filter_object.py
+++ b/src/maxo/dialogs/tools/filter_object.py
@@ -34,6 +34,8 @@ class CallableObject:
         return {k: kwargs[k] for k in self.params if k in kwargs}
 
     async def call(self, *args: Any, **kwargs: Any) -> Any:
+        # потому что update это первый аргумент в фильтрах и хендлерах
+        kwargs.pop("update", None)
         wrapped = partial(self.callback, *args, **self._prepare_kwargs(kwargs))
         if self.awaitable:
             return await wrapped()

--- a/src/maxo/dialogs/tools/filter_object.py
+++ b/src/maxo/dialogs/tools/filter_object.py
@@ -47,7 +47,7 @@ class FilterObject(CallableObject):
     magic: DialogMagic | None = None
 
     def __post_init__(self) -> None:
-        if isinstance(self.callback, DialogMagic):
+        if isinstance(self.callback, DialogMagic):  # type: ignore[misc]
             self.magic = self.callback
             self.callback = self.callback.resolve
 

--- a/src/maxo/dialogs/widgets/input/text.py
+++ b/src/maxo/dialogs/widgets/input/text.py
@@ -74,7 +74,7 @@ class TextInput(BaseInput, Generic[T]):
     ) -> bool:
         if message.message.body is None:
             return False
-        if message.message.body.text is None:
+        if not message.message.body.text:
             return False
 
         if self.filter and not await self.filter.call(

--- a/src/maxo/routing/handlers/signal.py
+++ b/src/maxo/routing/handlers/signal.py
@@ -56,7 +56,7 @@ class SignalHandler(Handler[_SignalT, _ReturnT_co], Generic[_SignalT, _ReturnT_c
 
     def _prepare_kwargs(self, ctx: Ctx) -> dict[str, Any]:
         if self._varkw:
-            return ctx
+            return dict(ctx)
 
         return {k: ctx[k] for k in self._params if k in ctx}
 

--- a/src/maxo/routing/handlers/update.py
+++ b/src/maxo/routing/handlers/update.py
@@ -69,6 +69,7 @@ class UpdateHandler(
         return await self._filter(ctx["update"], ctx)
 
     async def __call__(self, ctx: Ctx) -> _ReturnT_co:
+        # потому что update это первый аргумент в хендлерах
         update = ctx.pop("update")
         wrapped = partial(self._handler_fn, update, **self._prepare_kwargs(ctx))
         ctx["update"] = update

--- a/src/maxo/routing/handlers/update.py
+++ b/src/maxo/routing/handlers/update.py
@@ -61,7 +61,7 @@ class UpdateHandler(
 
     def _prepare_kwargs(self, ctx: Ctx) -> dict[str, Any]:
         if self._varkw:
-            return ctx
+            return dict(ctx)
 
         return {k: ctx[k] for k in self._params if k in ctx}
 

--- a/tests/maxo_dialog/test_storage_proxy.py
+++ b/tests/maxo_dialog/test_storage_proxy.py
@@ -84,8 +84,6 @@ async def test_save_load_stack_with_all_attachments():
     )
 
     await storage_proxy.save_stack(original_stack)
-    # When stack is saved it is unlocked, so we need to lock it again to load
-    await storage_proxy.unlock()
     loaded_stack = await storage_proxy.load_stack("test_stack")
 
     assert loaded_stack is not None

--- a/tests/maxo_dialog/test_storage_proxy.py
+++ b/tests/maxo_dialog/test_storage_proxy.py
@@ -1,0 +1,119 @@
+import pytest
+
+from maxo.dialogs.api.entities import Stack
+from maxo.dialogs.context.storage import StorageProxy
+from maxo.dialogs.test_tools.bot_client import FakeBot
+from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
+from maxo.enums import ChatType
+from maxo.fsm.key_builder import DefaultKeyBuilder
+from maxo.fsm.storages.memory import SimpleEventIsolation
+from maxo.types import (
+    AudioAttachment,
+    CallbackButton,
+    ContactAttachment,
+    FileAttachment,
+    InlineKeyboardAttachment,
+    LocationAttachment,
+    PhotoAttachment,
+    ShareAttachment,
+    StickerAttachment,
+    VideoAttachment,
+)
+
+
+@pytest.mark.asyncio
+async def test_save_load_stack_with_all_attachments():
+    bot = FakeBot()
+    chat_id = 123
+    user_id = 456
+    key_builder = DefaultKeyBuilder(with_destiny=True)
+    storage = JsonMemoryStorage()
+
+    storage_proxy = StorageProxy(
+        storage=storage,
+        events_isolation=SimpleEventIsolation(key_builder=key_builder),
+        user_id=user_id,
+        chat_id=chat_id,
+        chat_type=ChatType.DIALOG,
+        bot=bot,
+        state_groups={},
+    )
+
+    last_attachments = [
+        PhotoAttachment.factory(
+            photo_id=1,
+            token="photo_token",  # noqa: S106
+            url="https://example.com/photo.jpg",
+        ),
+        VideoAttachment.factory(
+            url="https://example.com/video.mp4",
+            token="video_token",  # noqa: S106
+        ),
+        AudioAttachment.factory(
+            url="https://example.com/audio.mp3",
+            token="audio_token",  # noqa: S106
+        ),
+        FileAttachment.factory(
+            url="https://example.com/file.txt",
+            token="file_token",  # noqa: S106
+            filename="file.txt",
+            size=123,
+        ),
+        StickerAttachment.factory(
+            url="https://example.com/sticker.webp",
+            code="sticker_code",
+            width=128,
+            height=128,
+        ),
+        ContactAttachment.factory(),
+        InlineKeyboardAttachment.factory(
+            buttons=[[CallbackButton(text="test", payload="test_payload")]],
+        ),
+        ShareAttachment.factory(
+            url="http://example.com",
+            token="share_token",  # noqa: S106
+        ),
+        LocationAttachment(latitude=55.7558, longitude=37.6173),
+    ]
+    original_stack = Stack(
+        _id="test_stack",
+        intents=["a", "b"],
+        last_message_id="12345",
+        last_sequence_id=1,
+        last_attachments=last_attachments,
+    )
+
+    await storage_proxy.save_stack(original_stack)
+    # When stack is saved it is unlocked, so we need to lock it again to load
+    await storage_proxy.unlock()
+    loaded_stack = await storage_proxy.load_stack("test_stack")
+
+    assert loaded_stack is not None
+    assert loaded_stack.id == original_stack.id
+    assert loaded_stack.intents == original_stack.intents
+    assert loaded_stack.last_message_id == original_stack.last_message_id
+    assert loaded_stack.last_sequence_id == original_stack.last_sequence_id
+    assert loaded_stack.last_attachments == original_stack.last_attachments
+
+    # Check that last_attachments are correctly deserialized
+    assert len(loaded_stack.last_attachments) == 9
+    assert isinstance(loaded_stack.last_attachments[0], PhotoAttachment)
+    assert isinstance(loaded_stack.last_attachments[1], VideoAttachment)
+    assert isinstance(loaded_stack.last_attachments[2], AudioAttachment)
+    assert isinstance(loaded_stack.last_attachments[3], FileAttachment)
+    assert isinstance(loaded_stack.last_attachments[4], StickerAttachment)
+    assert isinstance(loaded_stack.last_attachments[5], ContactAttachment)
+    assert isinstance(loaded_stack.last_attachments[6], InlineKeyboardAttachment)
+    assert isinstance(loaded_stack.last_attachments[7], ShareAttachment)
+    assert isinstance(loaded_stack.last_attachments[8], LocationAttachment)
+
+    assert loaded_stack.last_attachments[0].payload.token == "photo_token"  # noqa: S105
+    assert loaded_stack.last_attachments[1].payload.token == "video_token"  # noqa: S105
+    assert loaded_stack.last_attachments[2].payload.token == "audio_token"  # noqa: S105
+    assert loaded_stack.last_attachments[3].payload.token == "file_token"  # noqa: S105
+    assert loaded_stack.last_attachments[4].payload.code == "sticker_code"
+    assert (
+        loaded_stack.last_attachments[6].payload.buttons[0][0].payload == "test_payload"
+    )
+    assert loaded_stack.last_attachments[7].payload.token == "share_token"  # noqa: S105
+    assert loaded_stack.last_attachments[8].latitude == 55.7558


### PR DESCRIPTION
# Описание

- Исправил вызов `CallbackObject.call`, который не убирал `"update"` перед `prepare_kwargs`
- Исправил сохранение аттачментов в стэке для `OldMessage`

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Как это было протестировано?

Тест `test_storage_proxy.py` и прогон `examples/dialogs_form.py`

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Валидация текстовых полей: пустые строки теперь считаются некорректными.
  * Обработка сообщений: при отсутствии встроенной клавиатуры больше не выполняются лишние правки.
  * Передача параметров в обработчики: контекст копируется, чтобы избежать нежелательной мутации.

* **Улучшения**
  * Сериализация стеков обновлена — сохраняются и восстанавливаются последние вложения.

* **Примеры**
  * Пример диалога: заменён виджет ввода имени на управляемое текстовое поле.

* **Тесты**
  * Добавлен тест для сохранения/загрузки стеков с разными типами вложений.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->