### PR TITLE
Поддержка отправки `MediaAttachmentsRequests` через фасады

### DIFF
--- a/docs/pages/event-handling/facades.rst
+++ b/docs/pages/event-handling/facades.rst
@@ -29,6 +29,58 @@
 - **Управление клавиатурами**: методы для быстрой отправки или редактирования клавиатур.
 - **Доступ к боту**: через свойство ``facade.bot`` всегда доступен экземпляр бота.
 
+Отправка медиа
+--------------
+
+Фасады поддерживают отправку медиа двумя способами:
+
+- **Загрузка файла** - через ``InputFile`` (``BufferedInputFile``, ``FSInputFile``). Файл загружается на сервер автоматически.
+- **По токену** - через ``MediaAttachmentsRequests`` (``PhotoAttachmentRequest``, ``VideoAttachmentRequest`` и т.д.). Используется, когда медиа уже загружено ранее и известен его токен.
+
+Оба варианта можно передавать в параметр ``media`` методов ``send_message``, ``send_media`` и ``edit_message``. Тип ``MediaInput`` объединяет оба варианта:
+
+.. code-block:: python
+
+    from maxo.utils.facades.methods.attachments import MediaInput
+
+Загрузка файла
+~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from maxo.utils.upload_media import BufferedInputFile
+
+    photo = BufferedInputFile.image(content, "photo.jpg")
+    await facade.send_media(media=photo, text="Новое фото")
+
+Отправка по токену
+~~~~~~~~~~~~~~~~~~
+
+Если медиа уже было загружено или получено из входящего сообщения, можно использовать токен напрямую:
+
+.. code-block:: python
+
+    from maxo.types import PhotoAttachmentRequest
+
+    photo = PhotoAttachmentRequest.factory(token=token)
+    await facade.send_media(media=photo, text="Фото по токену")
+
+Комбинирование
+~~~~~~~~~~~~~~
+
+Можно смешивать оба типа в одном вызове - порядок вложений сохраняется:
+
+.. code-block:: python
+
+    from maxo.types import PhotoAttachmentRequest, VideoAttachmentRequest
+    from maxo.utils.upload_media import BufferedInputFile
+
+    media = [
+        BufferedInputFile.image(new_photo_bytes, "photo.jpg"),
+        VideoAttachmentRequest.factory(token=existing_video_token),
+    ]
+    await facade.send_message(text="Микс медиа", media=media)
+
 Список доступных фасадов
 ------------------------
 

--- a/examples/attachments_from_user.py
+++ b/examples/attachments_from_user.py
@@ -34,9 +34,8 @@ async def audio_handler(
     facade: MessageCreatedFacade,
 ) -> None:
     await facade.answer_text("Получил голосовое сообщение")
-    await facade.bot.send_message(
-        chat_id=facade.chat_id,
-        attachments=[update.message.body.audio],
+    await facade.send_message(
+        media=[update.message.body.audio.to_request()],
     )
 
 
@@ -57,10 +56,9 @@ async def file_handler(
     update: MessageCreated,
     facade: MessageCreatedFacade,
 ) -> None:
-    await facade.answer_text("Получил сообщение с файлами")
-    await facade.bot.send_message(
-        chat_id=facade.chat_id,
-        attachments=[update.message.body.file],
+    await facade.answer_text("Получил сообщение с файлом")
+    await facade.send_message(
+        media=[update.message.body.file.to_request()],
     )
 
 
@@ -70,9 +68,8 @@ async def image_handler(
     facade: MessageCreatedFacade,
 ) -> None:
     await facade.answer_text("Получил сообщение с изображениями")
-    await facade.bot.send_message(
-        chat_id=facade.chat_id,
-        attachments=update.message.body.photo,
+    await facade.send_message(
+        media=[photo.to_request() for photo in update.message.body.photo],
     )
 
 
@@ -118,9 +115,8 @@ async def video_handler(
     facade: MessageCreatedFacade,
 ) -> None:
     await facade.answer_text("Получил сообщение с видео")
-    await facade.bot.send_message(
-        chat_id=facade.chat_id,
-        attachments=[update.message.body.video],
+    await facade.send_message(
+        media=[video.to_request() for video in update.message.body.video],
     )
 
 

--- a/src/maxo/dialogs/manager/message_manager.py
+++ b/src/maxo/dialogs/manager/message_manager.py
@@ -25,6 +25,7 @@ from maxo.types import (
     PhotoAttachmentRequest,
     VideoAttachmentRequest,
 )
+from maxo.utils.facades.methods.attachments import MediaInput
 from maxo.utils.upload_media import FSInputFile, InputFile
 
 logger = getLogger(__name__)
@@ -294,10 +295,7 @@ class MessageManager(MessageManagerProtocol):
         facade = DialogAttachmentsFacade(bot, media_id_storage=self.media_id_storage)
         return await facade.build_attachments(base=base, keyboard=keyboard, files=files)
 
-    def _convert_media(
-        self,
-        media: MediaAttachment,
-    ) -> InputFile | MediaAttachmentsRequests | None:
+    def _convert_media(self, media: MediaAttachment) -> MediaInput | None:
         if media.media_id:
             token = media.media_id.token
             url = None

--- a/src/maxo/utils/facades/methods/attachments.py
+++ b/src/maxo/utils/facades/methods/attachments.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Sequence
+from typing import TypeAlias
 
 from unihttp.http import UploadFile
 
@@ -23,13 +24,15 @@ from maxo.types import (
 from maxo.utils.facades.methods.bot import BotMethodsFacade
 from maxo.utils.upload_media import InputFile
 
+MediaInput: TypeAlias = InputFile | MediaAttachmentsRequests
+
 
 class AttachmentsFacade(BotMethodsFacade):
     async def build_attachments(
         self,
         base: Sequence[AttachmentsRequests],
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        files: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
+        files: Sequence[MediaInput] | None = None,
     ) -> Sequence[AttachmentsRequests]:
         attachments = list(base)
 
@@ -47,7 +50,7 @@ class AttachmentsFacade(BotMethodsFacade):
 
     async def _build_media(
         self,
-        files: Sequence[InputFile | MediaAttachmentsRequests],
+        files: Sequence[MediaInput],
     ) -> list[MediaAttachmentsRequests]:
         attachments: list[MediaAttachmentsRequests | None] = [None] * len(files)
         files_to_upload: list[InputFile] = []

--- a/src/maxo/utils/facades/methods/attachments.py
+++ b/src/maxo/utils/facades/methods/attachments.py
@@ -29,7 +29,7 @@ class AttachmentsFacade(BotMethodsFacade):
         self,
         base: Sequence[AttachmentsRequests],
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        files: Sequence[InputFile] | None = None,
+        files: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
     ) -> Sequence[AttachmentsRequests]:
         attachments = list(base)
 
@@ -41,16 +41,39 @@ class AttachmentsFacade(BotMethodsFacade):
             )
 
         if files:
+            attachments.extend(await self._build_media(files))
+
+        return attachments
+
+    async def _build_media(
+        self,
+        files: Sequence[InputFile | MediaAttachmentsRequests],
+    ) -> list[MediaAttachmentsRequests]:
+        attachments: list[MediaAttachmentsRequests | None] = [None] * len(files)
+        files_to_upload: list[InputFile] = []
+        file_indices: list[int] = []
+
+        for i, file in enumerate(files):
+            if isinstance(file, InputFile):
+                files_to_upload.append(file)
+                file_indices.append(i)
+            else:
+                attachments[i] = file
+
+        if files_to_upload:
+            uploaded_files = await self._upload_files(files_to_upload)
+            for i, uploaded_file in zip(file_indices, uploaded_files, strict=True):
+                attachments[i] = uploaded_file
+
             # TODO: Исправить костыль со сном, https://github.com/K1rL3s/maxo/issues/10
             # maxo.errors.api.MaxBotBadRequestError:
             # ('attachment.not.ready',
             # 'Key: errors.process.attachment.file.not.processed')
-            attachments.extend(await self.build_media_attachments(files))
             await asyncio.sleep(0.5)
 
-        return attachments
+        return [attachment for attachment in attachments if attachment]
 
-    async def build_media_attachments(
+    async def _upload_files(
         self,
         files: Sequence[InputFile],
     ) -> Sequence[MediaAttachmentsRequests]:

--- a/src/maxo/utils/facades/methods/attachments.py
+++ b/src/maxo/utils/facades/methods/attachments.py
@@ -64,7 +64,7 @@ class AttachmentsFacade(BotMethodsFacade):
                 attachments[i] = file
 
         if files_to_upload:
-            uploaded_files = await self._upload_files(files_to_upload)
+            uploaded_files = await self.build_media_attachments(files_to_upload)
             for i, uploaded_file in zip(file_indices, uploaded_files, strict=True):
                 attachments[i] = uploaded_file
 
@@ -74,9 +74,9 @@ class AttachmentsFacade(BotMethodsFacade):
             # 'Key: errors.process.attachment.file.not.processed')
             await asyncio.sleep(0.5)
 
-        return [attachment for attachment in attachments if attachment]
+        return [attachment for attachment in attachments if attachment is not None]
 
-    async def _upload_files(
+    async def build_media_attachments(
         self,
         files: Sequence[InputFile],
     ) -> Sequence[MediaAttachmentsRequests]:

--- a/src/maxo/utils/facades/methods/chat.py
+++ b/src/maxo/utils/facades/methods/chat.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from maxo.enums import TextFormat
 from maxo.omit import Omittable, Omitted
-from maxo.types.attachments import MediaAttachmentsRequests
 from maxo.types.buttons import InlineButtons
 from maxo.types.chat import Chat
 from maxo.types.chat_members_list import ChatMembersList
@@ -12,8 +11,7 @@ from maxo.types.message import Message
 from maxo.types.message_list import MessageList
 from maxo.types.new_message_link import NewMessageLink
 from maxo.types.simple_query_result import SimpleQueryResult
-from maxo.utils.facades.methods.attachments import AttachmentsFacade
-from maxo.utils.upload_media import InputFile
+from maxo.utils.facades.methods.attachments import AttachmentsFacade, MediaInput
 
 
 class ChatMethodsFacade(AttachmentsFacade, ABC):
@@ -30,7 +28,7 @@ class ChatMethodsFacade(AttachmentsFacade, ABC):
         format: TextFormat | None = None,
         disable_link_preview: Omittable[bool] = Omitted(),
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        media: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
+        media: Sequence[MediaInput] | None = None,
     ) -> Message:
         attachments = await self.build_attachments(
             base=[],

--- a/src/maxo/utils/facades/methods/chat.py
+++ b/src/maxo/utils/facades/methods/chat.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from maxo.enums import TextFormat
 from maxo.omit import Omittable, Omitted
+from maxo.types.attachments import MediaAttachmentsRequests
 from maxo.types.buttons import InlineButtons
 from maxo.types.chat import Chat
 from maxo.types.chat_members_list import ChatMembersList
@@ -29,7 +30,7 @@ class ChatMethodsFacade(AttachmentsFacade, ABC):
         format: TextFormat | None = None,
         disable_link_preview: Omittable[bool] = Omitted(),
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        media: Sequence[InputFile] | None = None,
+        media: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
     ) -> Message:
         attachments = await self.build_attachments(
             base=[],

--- a/src/maxo/utils/facades/methods/message.py
+++ b/src/maxo/utils/facades/methods/message.py
@@ -10,7 +10,7 @@ from maxo.types.chat_members_list import ChatMembersList
 from maxo.types.message import Message
 from maxo.types.new_message_link import NewMessageLink
 from maxo.types.simple_query_result import SimpleQueryResult
-from maxo.utils.facades.methods.attachments import AttachmentsFacade
+from maxo.utils.facades.methods.attachments import AttachmentsFacade, MediaInput
 from maxo.utils.helpers.calculating import calculate_chat_id_and_user_id
 from maxo.utils.upload_media import InputFile
 
@@ -37,7 +37,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         format: TextFormat | None = None,
         disable_link_preview: Omittable[bool] = Omitted(),
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        media: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
+        media: Sequence[MediaInput] | None = None,
     ) -> Message:
         recipient = self.message.recipient
         chat_id, user_id = calculate_chat_id_and_user_id(
@@ -99,11 +99,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
 
     async def send_media(
         self,
-        media: (
-            InputFile
-            | MediaAttachmentsRequests
-            | Sequence[InputFile | MediaAttachmentsRequests]
-        ),
+        media: MediaInput | Sequence[MediaInput],
         text: str | None = None,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         notify: Omittable[bool] = True,
@@ -128,7 +124,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         self,
         text: str | None = None,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        media: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
+        media: Sequence[MediaInput] | None = None,
         link: NewMessageLink | None = None,
         notify: bool = True,
         format: TextFormat | None = None,

--- a/src/maxo/utils/facades/methods/message.py
+++ b/src/maxo/utils/facades/methods/message.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 from maxo.enums import MessageLinkType, TextFormat
 from maxo.omit import Omittable, Omitted
+from maxo.types import MediaAttachmentsRequests
 from maxo.types.buttons import InlineButtons
 from maxo.types.chat import Chat
 from maxo.types.chat_members_list import ChatMembersList
@@ -36,7 +37,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         format: TextFormat | None = None,
         disable_link_preview: Omittable[bool] = Omitted(),
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        media: Sequence[InputFile] | None = None,
+        media: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
     ) -> Message:
         recipient = self.message.recipient
         chat_id, user_id = calculate_chat_id_and_user_id(
@@ -98,7 +99,11 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
 
     async def send_media(
         self,
-        media: InputFile | Sequence[InputFile],
+        media: (
+            InputFile
+            | MediaAttachmentsRequests
+            | Sequence[InputFile | MediaAttachmentsRequests]
+        ),
         text: str | None = None,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         notify: Omittable[bool] = True,
@@ -106,7 +111,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         link: NewMessageLink | None = None,
         disable_link_preview: Omittable[bool] = Omitted(),
     ) -> Message:
-        if isinstance(media, InputFile):
+        if isinstance(media, (InputFile, MediaAttachmentsRequests)):
             media = (media,)
 
         return await self.send_message(
@@ -123,7 +128,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         self,
         text: str | None = None,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
-        media: Sequence[InputFile] | None = None,
+        media: Sequence[InputFile | MediaAttachmentsRequests] | None = None,
         link: NewMessageLink | None = None,
         notify: bool = True,
         format: TextFormat | None = None,

--- a/tests/maxo/utils/test_attachments_facade.py
+++ b/tests/maxo/utils/test_attachments_facade.py
@@ -1,0 +1,162 @@
+from collections.abc import Sequence
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from maxo.bot.bot import Bot
+from maxo.types import (
+    PhotoAttachmentRequest,
+    VideoAttachmentRequest,
+)
+from maxo.utils.facades.methods.attachments import AttachmentsFacade, MediaInput
+from maxo.utils.upload_media import BufferedInputFile
+
+
+class DummyFacade(AttachmentsFacade):
+    @property
+    def bot(self) -> Bot:
+        return self._bot
+
+
+@pytest.fixture
+def bot_mock():
+    return AsyncMock(spec=Bot)
+
+
+@pytest.fixture
+def facade(bot_mock):
+    return DummyFacade(bot=bot_mock)
+
+
+@pytest.mark.asyncio
+async def test_build_media_only_input_files(facade: DummyFacade):
+    input_files = [
+        BufferedInputFile.image(b"photo_bytes", "photo.jpg"),
+        BufferedInputFile.video(b"video_bytes", "video.mp4"),
+    ]
+    uploaded_attachments = [
+        PhotoAttachmentRequest.factory(token="photo_token"),  # noqa: S106
+        VideoAttachmentRequest.factory(token="video_token"),  # noqa: S106
+    ]
+
+    with (
+        patch.object(
+            facade,
+            "_upload_files",
+            new_callable=AsyncMock,
+        ) as upload_files_mock,
+        patch(
+            "asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep_mock,
+    ):
+        upload_files_mock.return_value = uploaded_attachments
+        result = await facade._build_media(input_files)
+
+        upload_files_mock.assert_called_once_with(input_files)
+        sleep_mock.assert_awaited_once_with(0.5)
+
+    assert result == uploaded_attachments
+
+
+@pytest.mark.asyncio
+async def test_build_media_only_requests(facade: DummyFacade):
+    requests = [
+        PhotoAttachmentRequest.factory(token="photo_token"),  # noqa: S106
+        VideoAttachmentRequest.factory(token="video_token"),  # noqa: S106
+    ]
+
+    with (
+        patch.object(
+            facade,
+            "_upload_files",
+            new_callable=AsyncMock,
+        ) as upload_files_mock,
+        patch(
+            "asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep_mock,
+    ):
+        result = await facade._build_media(requests)
+
+        upload_files_mock.assert_not_called()
+        sleep_mock.assert_not_awaited()
+
+    assert result == requests
+
+
+@pytest.mark.asyncio
+async def test_build_media_mixed_order(facade: DummyFacade):
+    input_file1 = BufferedInputFile.image(b"photo_bytes", "photo.jpg")
+    request1 = VideoAttachmentRequest.factory(token="video_token")  # noqa: S106
+    input_file2 = BufferedInputFile.image(b"photo_bytes2", "photo2.jpg")
+    request2 = VideoAttachmentRequest.factory(token="video_token2")  # noqa: S106
+
+    media: Sequence[MediaInput] = [input_file1, request1, input_file2, request2]
+
+    uploaded_attachments = [
+        PhotoAttachmentRequest.factory(token="photo_token"),  # noqa: S106
+        PhotoAttachmentRequest.factory(token="photo_token2"),  # noqa: S106
+    ]
+
+    expected_result = [
+        uploaded_attachments[0],
+        request1,
+        uploaded_attachments[1],
+        request2,
+    ]
+
+    with (
+        patch.object(
+            facade,
+            "_upload_files",
+            new_callable=AsyncMock,
+        ) as upload_files_mock,
+        patch(
+            "asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep_mock,
+    ):
+        upload_files_mock.return_value = uploaded_attachments
+        result = await facade._build_media(media)
+
+        upload_files_mock.assert_called_once_with([input_file1, input_file2])
+        sleep_mock.assert_awaited_once_with(0.5)
+
+    assert result == expected_result
+
+
+@pytest.mark.asyncio
+async def test_build_attachments_no_files(facade: DummyFacade):
+    with patch.object(
+        facade,
+        "_build_media",
+        new_callable=AsyncMock,
+    ) as build_media_mock:
+        result = await facade.build_attachments(base=[], files=None, keyboard=None)
+        build_media_mock.assert_not_called()
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_build_attachments_with_files(facade: DummyFacade):
+    input_files = [BufferedInputFile.image(b"photo_bytes", "photo.jpg")]
+    built_media = [
+        PhotoAttachmentRequest.factory(token="photo_token"),  # noqa: S106
+    ]
+
+    with patch.object(
+        facade,
+        "_build_media",
+        new_callable=AsyncMock,
+    ) as build_media_mock:
+        build_media_mock.return_value = built_media
+        result = await facade.build_attachments(
+            base=[],
+            files=input_files,
+            keyboard=None,
+        )
+        build_media_mock.assert_called_once_with(input_files)
+
+    assert result == built_media

--- a/tests/maxo/utils/test_attachments_facade.py
+++ b/tests/maxo/utils/test_attachments_facade.py
@@ -52,18 +52,18 @@ async def test_build_media_only_input_files(facade: DummyFacade) -> None:
     with (
         patch.object(
             facade,
-            "_upload_files",
+            "build_media_attachments",
             new_callable=AsyncMock,
-        ) as upload_files_mock,
+        ) as build_media_attachments_mock,
         patch(
             "asyncio.sleep",
             new_callable=AsyncMock,
         ) as sleep_mock,
     ):
-        upload_files_mock.return_value = uploaded_attachments
+        build_media_attachments_mock.return_value = uploaded_attachments
         result = await facade._build_media(input_files)
 
-        upload_files_mock.assert_called_once_with(input_files)
+        build_media_attachments_mock.assert_called_once_with(input_files)
         sleep_mock.assert_awaited_once_with(0.5)
 
     assert result == uploaded_attachments
@@ -79,9 +79,9 @@ async def test_build_media_only_requests(facade: DummyFacade) -> None:
     with (
         patch.object(
             facade,
-            "_upload_files",
+            "build_media_attachments",
             new_callable=AsyncMock,
-        ) as upload_files_mock,
+        ) as build_media_attachments_mock,
         patch(
             "asyncio.sleep",
             new_callable=AsyncMock,
@@ -89,7 +89,7 @@ async def test_build_media_only_requests(facade: DummyFacade) -> None:
     ):
         result = await facade._build_media(requests)
 
-        upload_files_mock.assert_not_called()
+        build_media_attachments_mock.assert_not_called()
         sleep_mock.assert_not_awaited()
 
     assert result == requests
@@ -119,7 +119,7 @@ async def test_build_media_mixed_order(facade: DummyFacade) -> None:
     with (
         patch.object(
             facade,
-            "_upload_files",
+            "build_media_attachments",
             new_callable=AsyncMock,
         ) as upload_files_mock,
         patch(

--- a/tests/maxo/utils/test_attachments_facade.py
+++ b/tests/maxo/utils/test_attachments_facade.py
@@ -9,27 +9,37 @@ from maxo.types import (
     VideoAttachmentRequest,
 )
 from maxo.utils.facades.methods.attachments import AttachmentsFacade, MediaInput
+from maxo.utils.facades.methods.message import MessageMethodsFacade
 from maxo.utils.upload_media import BufferedInputFile
 
 
 class DummyFacade(AttachmentsFacade):
+    pass
+
+
+class DummyMessageFacade(MessageMethodsFacade):
     @property
-    def bot(self) -> Bot:
-        return self._bot
+    def message(self) -> object:
+        return AsyncMock()
 
 
 @pytest.fixture
-def bot_mock():
+def bot_mock() -> AsyncMock:
     return AsyncMock(spec=Bot)
 
 
 @pytest.fixture
-def facade(bot_mock):
+def facade(bot_mock) -> DummyFacade:
     return DummyFacade(bot=bot_mock)
 
 
+@pytest.fixture
+def message_facade(bot_mock) -> DummyMessageFacade:
+    return DummyMessageFacade(bot=bot_mock)
+
+
 @pytest.mark.asyncio
-async def test_build_media_only_input_files(facade: DummyFacade):
+async def test_build_media_only_input_files(facade: DummyFacade) -> None:
     input_files = [
         BufferedInputFile.image(b"photo_bytes", "photo.jpg"),
         BufferedInputFile.video(b"video_bytes", "video.mp4"),
@@ -60,7 +70,7 @@ async def test_build_media_only_input_files(facade: DummyFacade):
 
 
 @pytest.mark.asyncio
-async def test_build_media_only_requests(facade: DummyFacade):
+async def test_build_media_only_requests(facade: DummyFacade) -> None:
     requests = [
         PhotoAttachmentRequest.factory(token="photo_token"),  # noqa: S106
         VideoAttachmentRequest.factory(token="video_token"),  # noqa: S106
@@ -86,7 +96,7 @@ async def test_build_media_only_requests(facade: DummyFacade):
 
 
 @pytest.mark.asyncio
-async def test_build_media_mixed_order(facade: DummyFacade):
+async def test_build_media_mixed_order(facade: DummyFacade) -> None:
     input_file1 = BufferedInputFile.image(b"photo_bytes", "photo.jpg")
     request1 = VideoAttachmentRequest.factory(token="video_token")  # noqa: S106
     input_file2 = BufferedInputFile.image(b"photo_bytes2", "photo2.jpg")
@@ -127,7 +137,7 @@ async def test_build_media_mixed_order(facade: DummyFacade):
 
 
 @pytest.mark.asyncio
-async def test_build_attachments_no_files(facade: DummyFacade):
+async def test_build_attachments_no_files(facade: DummyFacade) -> None:
     with patch.object(
         facade,
         "_build_media",
@@ -140,7 +150,7 @@ async def test_build_attachments_no_files(facade: DummyFacade):
 
 
 @pytest.mark.asyncio
-async def test_build_attachments_with_files(facade: DummyFacade):
+async def test_build_attachments_with_files(facade: DummyFacade) -> None:
     input_files = [BufferedInputFile.image(b"photo_bytes", "photo.jpg")]
     built_media = [
         PhotoAttachmentRequest.factory(token="photo_token"),  # noqa: S106
@@ -160,3 +170,21 @@ async def test_build_attachments_with_files(facade: DummyFacade):
         build_media_mock.assert_called_once_with(input_files)
 
     assert result == built_media
+
+
+@pytest.mark.asyncio
+async def test_send_media_single_media_attachments_request(
+    message_facade: DummyMessageFacade,
+) -> None:
+    request = PhotoAttachmentRequest.factory(token="photo_token")  # noqa: S106
+
+    with patch.object(
+        message_facade,
+        "send_message",
+        new_callable=AsyncMock,
+    ) as send_message_mock:
+        send_message_mock.return_value = AsyncMock()
+        await message_facade.send_media(media=request)
+
+        send_message_mock.assert_called_once()
+        assert send_message_mock.call_args[1]["media"] == (request,)


### PR DESCRIPTION
# Описание

Поддержка отправки `MediaAttachmentsRequests` вместе с `InputFile` через фасады

Fix #84

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [x] Документация (опечатки, примеры кода или любые другие обновления документации)
- [x] Новый функционал (некритическое изменение, добавляющее функциональность)
- [x] Это изменение требует обновления документации

# Как это было протестировано?

`test_attachments_facade.py`

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я внес соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Отправка/редактирование сообщений и медиа теперь принимает смешанные медиа-входы (загрузка файлов и существующие медиа-токены) в одном вызове, сохраняется порядок.

* **Improvements**
  * Сборка вложений оптимизирована: готовые медиа-токены переиспользуются, загружаются только файлы, уменьшено число операций.

* **Tests**
  * Добавлены тесты для всех сочетаний файлов и готовых медиа-токенов.

* **Documentation**
  * Добавлен раздел с примерами использования смешанных медиа-входов.

* **Examples**
  * Примеры обновлены для использования нового параметра media в вызовах.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->