### PR TITLE
Исправление порядка обхода роутеров при срабатывании фильтра

### DIFF
--- a/src/maxo/routing/observers/base.py
+++ b/src/maxo/routing/observers/base.py
@@ -74,7 +74,6 @@ class BaseObserver(Observer[_UpdateT, _HandlerT, _HandlerFnT], ABC):
         return await self._filter(ctx["update"], ctx)
 
     async def handler_lookup(self, ctx: Ctx) -> Any:
-
         for handler in self._handlers:
             if await handler.execute_filter(ctx):
                 try:

--- a/src/maxo/routing/observers/base.py
+++ b/src/maxo/routing/observers/base.py
@@ -74,8 +74,6 @@ class BaseObserver(Observer[_UpdateT, _HandlerT, _HandlerFnT], ABC):
         return await self._filter(ctx["update"], ctx)
 
     async def handler_lookup(self, ctx: Ctx) -> Any:
-        if not await self.execute_filter(ctx):
-            return UNHANDLED
 
         for handler in self._handlers:
             if await handler.execute_filter(ctx):

--- a/src/maxo/routing/observers/signal.py
+++ b/src/maxo/routing/observers/signal.py
@@ -31,9 +31,6 @@ class SignalObserver(
         return handler_fn
 
     async def handler_lookup(self, ctx: Ctx) -> Any:
-        if not await self.execute_filter(ctx):
-            return UNHANDLED
-
         for handler in self._handlers:
             if await handler.execute_filter(ctx):
                 await self.execute_handler(ctx, handler)

--- a/src/maxo/routing/routers/simple.py
+++ b/src/maxo/routing/routers/simple.py
@@ -149,6 +149,7 @@ class Router(BaseRouter):
     async def _trigger(self, ctx: Ctx, *, observer: Observer) -> Any:
         if not await observer.execute_filter(ctx):
             return UNHANDLED
+
         result = await observer.handler_lookup(ctx)
         if result is UNHANDLED:
             return await self.trigger_child(ctx)

--- a/src/maxo/routing/routers/simple.py
+++ b/src/maxo/routing/routers/simple.py
@@ -147,6 +147,8 @@ class Router(BaseRouter):
         return await chain_middlewares(ctx)
 
     async def _trigger(self, ctx: Ctx, *, observer: Observer) -> Any:
+        if not await observer.execute_filter(ctx):
+            return UNHANDLED
         result = await observer.handler_lookup(ctx)
         if result is UNHANDLED:
             return await self.trigger_child(ctx)

--- a/src/maxo/routing/routers/simple.py
+++ b/src/maxo/routing/routers/simple.py
@@ -146,7 +146,7 @@ class Router(BaseRouter):
         )
         return await chain_middlewares(ctx)
 
-    async def _trigger(self, ctx: Ctx, *, observer: Observer) -> Any:
+    async def _trigger(self, ctx: Ctx, *, observer: Observer[Any, Any, Any]) -> Any:
         if not await observer.execute_filter(ctx):
             return UNHANDLED
 

--- a/tests/maxo/routing/test_router_filters.py
+++ b/tests/maxo/routing/test_router_filters.py
@@ -108,8 +108,8 @@ async def test_parent_and_child_included_router_filters_allow_handler(ctx: Ctx) 
     ]
 
 
-@pytest.mark.asyncio
-async def test_child_included_router_filter_false_stops_after_parent_filter(ctx: Ctx) -> None:
+`@pytest.mark.asyncio`
+async def test_child_filter_false_stops_after_parent_filter(ctx: Ctx) -> None:
     dp = Dispatcher()
     parent_router = Router("parent")
     child_router = Router("child")

--- a/tests/maxo/routing/test_router_filters.py
+++ b/tests/maxo/routing/test_router_filters.py
@@ -108,7 +108,7 @@ async def test_parent_and_child_included_router_filters_allow_handler(ctx: Ctx) 
     ]
 
 
-`@pytest.mark.asyncio`
+@pytest.mark.asyncio
 async def test_child_filter_false_stops_after_parent_filter(ctx: Ctx) -> None:
     dp = Dispatcher()
     parent_router = Router("parent")

--- a/tests/maxo/routing/test_router_filters.py
+++ b/tests/maxo/routing/test_router_filters.py
@@ -1,0 +1,246 @@
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from maxo.enums import ChatType
+from maxo.routing.ctx import Ctx
+from maxo.routing.dispatcher import Dispatcher
+from maxo.routing.filters import BaseFilter
+from maxo.routing.routers.simple import Router
+from maxo.routing.sentinels import SkipHandler, UNHANDLED
+from maxo.routing.signals import BeforeStartup
+from maxo.routing.updates.message_created import MessageCreated
+from maxo.types import Message, MessageBody, Recipient, User
+
+
+@pytest.fixture
+def update() -> MessageCreated:
+    return MessageCreated(
+        message=Message(
+            body=MessageBody(mid="test", seq=1),
+            recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=1),
+            timestamp=datetime.now(UTC),
+            sender=User(
+                user_id=1,
+                first_name="Test",
+                is_bot=False,
+                last_activity_time=datetime.now(UTC),
+            ),
+        ),
+        timestamp=datetime.now(UTC),
+    )
+
+
+async def handler(_: Any, ctx: Ctx) -> str:
+    ctx["execution_order"].append("handler")
+    return "OK"
+
+
+async def skipping_handler(_: Any, ctx: Ctx) -> None:
+    ctx["execution_order"].append("skipping_handler")
+    raise SkipHandler
+
+
+@pytest.mark.asyncio
+async def test_parent_included_router_filter_false_blocks_child_router(
+    ctx: Ctx,
+) -> None:
+    dp = Dispatcher()
+    parent_router = Router("parent")
+    child_router = Router("child")
+    dp.include(parent_router)
+    parent_router.include(child_router)
+
+    class ParentFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("parent_filter")
+            return False
+
+    class ChildFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("child_filter")
+            return True
+
+    parent_router.message_created.filter(ParentFilter())
+    child_router.message_created.filter(ChildFilter())
+    child_router.message_created.handler(handler)
+
+    await dp.feed_signal(BeforeStartup())
+    ctx["execution_order"] = []
+    result = await dp.trigger(ctx)
+
+    assert result is UNHANDLED
+    assert ctx["execution_order"] == ["parent_filter"]
+
+
+@pytest.mark.asyncio
+async def test_parent_and_child_included_router_filters_allow_handler(ctx: Ctx) -> None:
+    dp = Dispatcher()
+    parent_router = Router("parent")
+    child_router = Router("child")
+    dp.include(parent_router)
+    parent_router.include(child_router)
+
+    class ParentFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("parent_filter")
+            return True
+
+    class ChildFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("child_filter")
+            return True
+
+    parent_router.message_created.filter(ParentFilter())
+    child_router.message_created.filter(ChildFilter())
+    child_router.message_created.handler(handler)
+
+    await dp.feed_signal(BeforeStartup())
+    ctx["execution_order"] = []
+    result = await dp.trigger(ctx)
+
+    assert result == "OK"
+    assert ctx["execution_order"] == [
+        "parent_filter",
+        "child_filter",
+        "handler",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_child_included_router_filter_false_stops_after_parent_filter(ctx: Ctx) -> None:
+    dp = Dispatcher()
+    parent_router = Router("parent")
+    child_router = Router("child")
+    dp.include(parent_router)
+    parent_router.include(child_router)
+
+    class ParentFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("parent_filter")
+            return True
+
+    class ChildFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("child_filter")
+            return False
+
+    parent_router.message_created.filter(ParentFilter())
+    child_router.message_created.filter(ChildFilter())
+    child_router.message_created.handler(handler)
+
+    await dp.feed_signal(BeforeStartup())
+    ctx["execution_order"] = []
+    result = await dp.trigger(ctx)
+
+    assert result is UNHANDLED
+    assert ctx["execution_order"] == [
+        "parent_filter",
+        "child_filter",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_filter_false_blocks_included_routers(ctx: Ctx) -> None:
+    dp = Dispatcher()
+    child_router = Router("child")
+    dp.include(child_router)
+
+    class DispatcherFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("dispatcher_filter")
+            return False
+
+    class ChildFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("child_filter")
+            return True
+
+    dp.message_created.filter(DispatcherFilter())
+    child_router.message_created.filter(ChildFilter())
+    child_router.message_created.handler(handler)
+
+    await dp.feed_signal(BeforeStartup())
+    ctx["execution_order"] = []
+    result = await dp.trigger(ctx)
+
+    assert result is UNHANDLED
+    assert ctx["execution_order"] == ["dispatcher_filter"]
+
+
+@pytest.mark.asyncio
+async def test_parent_handlers_filtered_out_falls_through_to_child(ctx: Ctx) -> None:
+    dp = Dispatcher()
+    parent_router = Router("parent")
+    child_router = Router("child")
+    dp.include(parent_router)
+    parent_router.include(child_router)
+
+    class ParentFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("parent_filter")
+            return True
+
+    class ParentHandlerFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("parent_handler_filter")
+            return False
+
+    class ChildFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("child_filter")
+            return True
+
+    parent_router.message_created.filter(ParentFilter())
+    parent_router.message_created.handler(handler, ParentHandlerFilter())
+    child_router.message_created.filter(ChildFilter())
+    child_router.message_created.handler(handler)
+
+    await dp.feed_signal(BeforeStartup())
+    ctx["execution_order"] = []
+    result = await dp.trigger(ctx)
+
+    assert result == "OK"
+    assert ctx["execution_order"] == [
+        "parent_filter",
+        "parent_handler_filter",
+        "child_filter",
+        "handler",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_skip_handler_in_parent_falls_through_to_child(ctx: Ctx) -> None:
+    dp = Dispatcher()
+    parent_router = Router("parent")
+    child_router = Router("child")
+    dp.include(parent_router)
+    parent_router.include(child_router)
+
+    class ParentFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("parent_filter")
+            return True
+
+    class ChildFilter(BaseFilter[MessageCreated]):
+        async def __call__(self, update: MessageCreated, ctx: Ctx) -> bool:
+            ctx["execution_order"].append("child_filter")
+            return True
+
+    parent_router.message_created.filter(ParentFilter())
+    parent_router.message_created.handler(skipping_handler)
+    child_router.message_created.filter(ChildFilter())
+    child_router.message_created.handler(handler)
+
+    await dp.feed_signal(BeforeStartup())
+    ctx["execution_order"] = []
+    result = await dp.trigger(ctx)
+
+    assert result == "OK"
+    assert ctx["execution_order"] == [
+        "parent_filter",
+        "skipping_handler",
+        "child_filter",
+        "handler",
+    ]

--- a/tests/maxo/routing/test_signals.py
+++ b/tests/maxo/routing/test_signals.py
@@ -5,6 +5,7 @@ import pytest
 from maxo import Router
 from maxo.enums import ChatType
 from maxo.routing.dispatcher import Dispatcher
+from maxo.routing.filters import BaseFilter
 from maxo.routing.middlewares.state import (
     EmptyMiddlewareManagerState,
     StartedMiddlewareManagerState,
@@ -17,6 +18,7 @@ from maxo.routing.signals import (
     BeforeStartup,
     MaxoUpdate,
 )
+from maxo.routing.ctx import Ctx
 from maxo.routing.updates.message_created import MessageCreated
 from maxo.types import Message, MessageBody, Recipient, User
 
@@ -174,3 +176,45 @@ async def test_dp_update_handler(update: MessageCreated, bot) -> None:
 
     await dp.feed_max_update(MaxoUpdate(update=update), bot)
     assert triggered
+
+
+@pytest.mark.asyncio
+async def test_signal_filter_false_blocks_handler() -> None:
+    dp = Dispatcher()
+    order = []
+
+    class BeforeStartupFilter(BaseFilter[BeforeStartup]):
+        async def __call__(self, update: BeforeStartup, ctx: Ctx) -> bool:
+            order.append("filter")
+            return False
+
+    dp.before_startup.filter(BeforeStartupFilter())
+
+    @dp.before_startup()
+    async def before_startup() -> None:
+        order.append("handler")
+
+    await dp.feed_signal(BeforeStartup())
+
+    assert order == ["filter"]
+
+
+@pytest.mark.asyncio
+async def test_signal_filter_called_once() -> None:
+    dp = Dispatcher()
+    order = []
+
+    class BeforeStartupFilter(BaseFilter[BeforeStartup]):
+        async def __call__(self, update: BeforeStartup, ctx: Ctx) -> bool:
+            order.append("filter")
+            return True
+
+    dp.before_startup.filter(BeforeStartupFilter())
+
+    @dp.before_startup()
+    async def before_startup() -> None:
+        order.append("handler")
+
+    await dp.feed_signal(BeforeStartup())
+
+    assert order == ["filter", "handler"]


### PR DESCRIPTION
# Описание

Исправление порядка обхода роутеров при срабатывании фильтра. Теперь дочерние роутеры не вызываются если фильтр False.
Перенесена проверка фильтра из handler_lookup() /src/maxo/routing/observers/base.py и /src/maxo/routing/observers/signal.py
в  _trigger() /src/maxo/routing/routers/simple.py

## Тип изменения

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Как это было протестировано?

uv run pytest tests/maxo/routing/test_signals.py tests/maxo/routing/test_router_filters.py

Описание

**Тестовая конфигурация**:
* Операционная система:  Windows [Version 10.0.19045.4170]
* Версия Python:  3.13.9

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Уточнена семантика фильтрации: наблюдатель больше не прерывает поиск обработчиков сам — маршрутизатор теперь выполняет предварительную проверку фильтра наблюдателя и блокирует вызов для непрошедших фильтр.

* **Тесты**
  * Добавлены подробные тесты для сценариев фильтрации маршрутов и сигналов, подтверждающие порядок вызовов, поведение пропуска/передачи и новую семантику.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->