### PR TITLE
Фикс автоинжекта дишки

### DIFF
--- a/src/maxo/integrations/dishka.py
+++ b/src/maxo/integrations/dishka.py
@@ -88,7 +88,12 @@ def setup_dishka(
 
     if auto_inject:
 
-        async def _auto_inject() -> None:
+        async def _auto_inject(ctx: Ctx) -> None:
+            # При вызове из Dispatcher._emit_before_startup_handler
+            # ещё не успел сработать DishkaMiddleware,
+            # но дишка уже инжектировалась в сигналы.
+            # Поэтому надо положить контейнер в ctx
+            ctx[CONTAINER_NAME] = container
             inject_router(dispatcher)
 
         dispatcher.before_startup.handler(_auto_inject)

--- a/src/maxo/integrations/dishka.py
+++ b/src/maxo/integrations/dishka.py
@@ -37,7 +37,7 @@ _ReturnT = TypeVar("_ReturnT")
 _ParamsP = ParamSpec("_ParamsP")
 _UpdateT = TypeVar("_UpdateT", bound=BaseUpdate)
 _SignalT = TypeVar("_SignalT", bound=BaseSignal)
-_Handler = TypeVar("_Handler", bound=UpdateHandler | SignalHandler)
+_Handler = TypeVar("_Handler", bound=UpdateHandler[Any, Any] | SignalHandler[Any, Any])
 
 
 _SignalHandlerFn = Callable[_ParamsP, _ReturnT]


### PR DESCRIPTION
# Описание

Исправил автоинжект дишки при наличии вложенных роутеров в диспетчер

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Как это было протестировано?

До фикса был такой трейсбек, после - всё работает
```python
/Users/k1rles/papka/code/maxoslop/.venv/bin/python /Users/k1rles/papka/code/maxoslop/maxobot/max/__main__.py
Traceback (most recent call last):
  File "/Users/k1rles/papka/code/maxoslop/maxobot/max/__main__.py", line 242, in <module>
    run(main())
  File "/Users/k1rles/papka/code/maxoslop/maxobot/runner.py", line 25, in run
    runner(entrypoint)  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/Users/k1rles/papka/code/maxoslop/maxobot/max/__main__.py", line 237, in main
    await LongPolling(dp).start(bot, drop_pending_updates=True)
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/transport/long_polling.py", line 78, in start
    await dispatcher.feed_signal(BeforeStartup())
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/dispatcher.py", line 104, in feed_signal
    return await self.feed_update(signal, bot)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/dispatcher.py", line 109, in feed_update
    return await self.trigger(ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/routers/simple.py", line 147, in trigger
    return await chain_middlewares(ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/routers/simple.py", line 152, in _trigger
    return await self.trigger_child(ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/routers/simple.py", line 133, in trigger_child
    result = await child_router.trigger(ctx)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/routers/simple.py", line 147, in trigger
    return await chain_middlewares(ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/routers/simple.py", line 150, in _trigger
    result = await observer.handler_lookup(ctx)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/observers/signal.py", line 39, in handler_lookup
    await self.execute_handler(ctx, handler)
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/observers/base.py", line 95, in execute_handler
    return cast(_ReturnT_co, await chain_middlewares(ctx))
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/routing/handlers/signal.py", line 69, in __call__
    return await wrapped()
           ^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/dishka/integrations/base.py", line 165, in auto_injected_func
    container = container_getter(args, kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/k1rles/papka/code/maxoslop/.venv/lib/python3.12/site-packages/maxo/integrations/dishka.py", line 75, in <lambda>
    container_getter=lambda _, kwargs: kwargs[CONTAINER_NAME],
                                       ~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'dishka_container'

Process finished with exit code 1
```

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код полностью написан мной без использования нейросетей


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Повышена надежность интеграции с Dishka путем обеспечения доступности контейнера во время инициализации диспетчера. Контейнер теперь корректно доступен на всех этапах запуска приложения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->