### PR TITLE
Установил `format: Omittable[TextFormat | None] = Omitted()` в фасадах

### DIFF
--- a/src/maxo/utils/facades/methods/chat.py
+++ b/src/maxo/utils/facades/methods/chat.py
@@ -25,7 +25,7 @@ class ChatMethodsFacade(AttachmentsFacade, ABC):
         text: str | None = None,
         link: NewMessageLink | None = None,
         notify: Omittable[bool] = True,
-        format: TextFormat | None = None,
+        format: Omittable[TextFormat | None] = Omitted(),
         disable_link_preview: Omittable[bool] = Omitted(),
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         media: Sequence[MediaInput] | None = None,

--- a/src/maxo/utils/facades/methods/message.py
+++ b/src/maxo/utils/facades/methods/message.py
@@ -34,7 +34,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         text: str | None = None,
         link: NewMessageLink | None = None,
         notify: Omittable[bool] = True,
-        format: TextFormat | None = None,
+        format: Omittable[TextFormat | None] = Omitted(),
         disable_link_preview: Omittable[bool] = Omitted(),
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         media: Sequence[MediaInput] | None = None,
@@ -69,7 +69,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         text: str,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         notify: Omittable[bool] = True,
-        format: TextFormat | None = None,
+        format: Omittable[TextFormat | None] = Omitted(),
         disable_link_preview: Omittable[bool] = Omitted(),
     ) -> Message:
         return await self.send_message(
@@ -85,7 +85,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         text: str,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         notify: Omittable[bool] = True,
-        format: TextFormat | None = None,
+        format: Omittable[TextFormat | None] = Omitted(),
         disable_link_preview: Omittable[bool] = Omitted(),
     ) -> Message:
         return await self.send_message(
@@ -103,7 +103,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         text: str | None = None,
         keyboard: Sequence[Sequence[InlineButtons]] | None = None,
         notify: Omittable[bool] = True,
-        format: TextFormat | None = None,
+        format: Omittable[TextFormat | None] = Omitted(),
         link: NewMessageLink | None = None,
         disable_link_preview: Omittable[bool] = Omitted(),
     ) -> Message:
@@ -127,7 +127,7 @@ class MessageMethodsFacade(AttachmentsFacade, ABC):
         media: Sequence[MediaInput] | None = None,
         link: NewMessageLink | None = None,
         notify: bool = True,
-        format: TextFormat | None = None,
+        format: Omittable[TextFormat | None] = Omitted(),
     ) -> Message:
         message_id = self.message.body.mid
 

--- a/tests/maxo/routing/test_router_filters.py
+++ b/tests/maxo/routing/test_router_filters.py
@@ -8,7 +8,7 @@ from maxo.routing.ctx import Ctx
 from maxo.routing.dispatcher import Dispatcher
 from maxo.routing.filters import BaseFilter
 from maxo.routing.routers.simple import Router
-from maxo.routing.sentinels import SkipHandler, UNHANDLED
+from maxo.routing.sentinels import UNHANDLED, SkipHandler
 from maxo.routing.signals import BeforeStartup
 from maxo.routing.updates.message_created import MessageCreated
 from maxo.types import Message, MessageBody, Recipient, User

--- a/tests/maxo/routing/test_signals.py
+++ b/tests/maxo/routing/test_signals.py
@@ -4,6 +4,7 @@ import pytest
 
 from maxo import Router
 from maxo.enums import ChatType
+from maxo.routing.ctx import Ctx
 from maxo.routing.dispatcher import Dispatcher
 from maxo.routing.filters import BaseFilter
 from maxo.routing.middlewares.state import (
@@ -18,7 +19,6 @@ from maxo.routing.signals import (
     BeforeStartup,
     MaxoUpdate,
 )
-from maxo.routing.ctx import Ctx
 from maxo.routing.updates.message_created import MessageCreated
 from maxo.types import Message, MessageBody, Recipient, User
 


### PR DESCRIPTION
# Описание

В фасадах стоял `format = None`, а не `Omitted`, из-за этого при отправке через фасады сбивается форматирование текста. Установил `format: Omittable[TextFormat | None] = Omitted()` в фасадах

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)


# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код полностью написан мной без использования нейросетей


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Refactor**
  * Внутренние улучшения параметров методов отправки сообщений.

* **Chores**
  * Оптимизация импортов в тестовых модулях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->