### PR TITLE
Фикс работы `ListGroup` не с `CallbackButton`

### DIFF
--- a/src/maxo/dialogs/widgets/kbd/list_group.py
+++ b/src/maxo/dialogs/widgets/kbd/list_group.py
@@ -58,10 +58,8 @@ class ListGroup(Keyboard):
             b_kbd = await b.render_keyboard(data, sub_manager)
             for row in b_kbd:
                 for btn in row:
-                    if btn.payload:
-                        btn.payload = self._item_payload(
-                            f"{item_id}:{btn.payload}",
-                        )
+                    if hasattr(btn, "payload"):
+                        btn.payload = self._item_payload(f"{item_id}:{btn.payload}")
             kbd.extend(b_kbd)
         return kbd
 

--- a/src/maxo/types/callback_button.py
+++ b/src/maxo/types/callback_button.py
@@ -15,3 +15,8 @@ class CallbackButton(Button):
 
     payload: str
     """Токен кнопки"""
+
+    # Подражание aiogram
+    @property
+    def callback_data(self) -> str:
+        return self.payload

--- a/tests/maxo_dialog/widgets/kbd/test_list_group.py
+++ b/tests/maxo_dialog/widgets/kbd/test_list_group.py
@@ -2,15 +2,15 @@ import pytest
 
 from maxo.dialogs import DialogManager
 from maxo.dialogs.widgets.kbd import ListGroup
-from maxo.dialogs.widgets.kbd.button import Url
-from maxo.dialogs.widgets.text import Const
+from maxo.dialogs.widgets.kbd.button import Button, Url
+from maxo.dialogs.widgets.text import Const, Format
 
 
 @pytest.mark.asyncio
 async def test_render_list_group_with_url_button(mock_manager: DialogManager) -> None:
     list_group = ListGroup(
         Url(Const("Url"), url=Const("https://test.com")),
-        id="test_list",
+        id="list",
         items=["a", "b", "c"],
         item_id_getter=lambda item: item,
     )
@@ -21,3 +21,29 @@ async def test_render_list_group_with_url_button(mock_manager: DialogManager) ->
     assert len(keyboard[0]) == 1
     assert keyboard[0][0].text == "Url"
     assert keyboard[0][0].url == "https://test.com"
+
+
+@pytest.mark.asyncio
+async def test_render_list_group_with_callback_button(mock_manager: DialogManager) -> None:
+    list_group = ListGroup(
+        Button(Format("Callback {item}"), "button"),
+        id="list",
+        items=["a", "b", "c"],
+        item_id_getter=lambda item: item,
+    )
+
+    keyboard = await list_group.render_keyboard(data={}, manager=mock_manager)
+
+    assert len(keyboard) == 3
+
+    assert len(keyboard[0]) == 1
+    assert keyboard[0][0].text == "Callback a"
+    assert keyboard[0][0].payload == "list:a:button"
+
+    assert len(keyboard[2]) == 1
+    assert keyboard[1][0].text == "Callback b"
+    assert keyboard[1][0].payload == "list:b:button"
+
+    assert len(keyboard[2]) == 1
+    assert keyboard[2][0].text == "Callback c"
+    assert keyboard[2][0].payload == "list:c:button"

--- a/tests/maxo_dialog/widgets/kbd/test_list_group.py
+++ b/tests/maxo_dialog/widgets/kbd/test_list_group.py
@@ -1,0 +1,23 @@
+import pytest
+
+from maxo.dialogs import DialogManager
+from maxo.dialogs.widgets.kbd import ListGroup
+from maxo.dialogs.widgets.kbd.button import Url
+from maxo.dialogs.widgets.text import Const
+
+
+@pytest.mark.asyncio
+async def test_render_list_group_with_url_button(mock_manager: DialogManager) -> None:
+    list_group = ListGroup(
+        Url(Const("Url"), url=Const("https://test.com")),
+        id="test_list",
+        items=["a", "b", "c"],
+        item_id_getter=lambda item: item,
+    )
+
+    keyboard = await list_group.render_keyboard(data={}, manager=mock_manager)
+
+    assert len(keyboard) == 3
+    assert len(keyboard[0]) == 1
+    assert keyboard[0][0].text == "Url"
+    assert keyboard[0][0].url == "https://test.com"


### PR DESCRIPTION
# Описание

Исправил работу диаложного виджета `ListGroup` не с `CallbackButton`

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Bug Fixes**
  * Улучшена обработка параметров кнопок при отображении списков элементов (корректнее обрабатываются пустые и специальные значения).

* **New Features**
  * Добавлено новое свойство у кнопок для удобного доступа к данным обратного вызова.

* **Tests**
  * Добавлены тесты: проверка отображения кнопок с URL и проверки формирования данных обратного вызова в списках.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->