### PR TITLE
Убрал из `MagicData` и `MagicFilter` лишний `.cast(bool)`

### DIFF
--- a/src/maxo/integrations/magic_filter.py
+++ b/src/maxo/integrations/magic_filter.py
@@ -19,7 +19,7 @@ class MagicData(BaseFilter[Any]):
         magic_filter: OriginMagicFilter,
         result_key: str | None = None,
     ) -> None:
-        self._magic_filter = magic_filter.cast(bool)
+        self._magic_filter = magic_filter
         self._result_key = result_key
 
     async def __call__(self, update: Any, ctx: Ctx) -> bool:
@@ -42,7 +42,7 @@ class MagicFilter(BaseFilter[Any]):
         magic_filter: OriginMagicFilter,
         result_key: str | None = None,
     ) -> None:
-        self._magic_filter = magic_filter.cast(bool)
+        self._magic_filter = magic_filter
         self._result_key = result_key
 
     async def __call__(self, update: Any, ctx: Ctx) -> bool:

--- a/tests/maxo/integrations/test_magic_filter.py
+++ b/tests/maxo/integrations/test_magic_filter.py
@@ -1,0 +1,30 @@
+import pytest
+from magic_filter import F
+
+from maxo.integrations.magic_filter import MagicData, MagicFilter
+
+
+@pytest.mark.asyncio
+async def test_magic_filter_custom_cast() -> None:
+    magic_filter = MagicFilter(F["item"].cast(str), result_key="result")
+
+    ctx = {}
+    result = await magic_filter({"item": 42}, ctx)
+
+    assert result is True
+    assert "result" in ctx
+    assert ctx["result"] == "42"
+    assert isinstance(ctx["result"], str)
+
+
+@pytest.mark.asyncio
+async def test_magic_data_custom_cast() -> None:
+    magic_data = MagicData(F["item"].cast(str), result_key="result")
+
+    ctx = {"item": 42}
+    result = await magic_data(None, ctx)
+
+    assert result is True
+    assert "result" in ctx
+    assert ctx["result"] == "42"
+    assert isinstance(ctx["result"], str)


### PR DESCRIPTION
# Описание

Убрал лишний `.cast(bool)` из интеграции с `magic_filter`, чтобы он не перезаписывал пользовательский каст

## Тип изменения

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Как это было протестировано?

`test_magic_filter.py`

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код полностью написан мной без использования нейросетей


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Скорректирована обработка пользовательских преобразований типов в фильтрах для более надежной работы.

* **Тесты**
  * Добавлены новые интеграционные тесты для проверки корректности работы преобразования типов в различных сценариях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->