### PR TITLE
fix(dialogs): storage_proxy и access_validator корректно обрабатывают channel-сообщения без user

### DIFF
--- a/src/maxo/dialogs/context/access_validator.py
+++ b/src/maxo/dialogs/context/access_validator.py
@@ -26,7 +26,11 @@ class DefaultAccessValidator(StackAccessValidator):
         if not (access_settings.user_ids or access_settings.custom):
             return True
 
-        user: User = ctx[EVENT_FROM_USER_KEY]
+        user: User | None = ctx.get(EVENT_FROM_USER_KEY)
+        # Если access требует user_ids а user отсутствует (например, пост в канале)
+        # - доступ запрещён, AttributeError быть не должен
+        if user is None:
+            return False
         if user.id in access_settings.user_ids:  # noqa: SIM103
             return True
 

--- a/src/maxo/dialogs/context/access_validator.py
+++ b/src/maxo/dialogs/context/access_validator.py
@@ -5,7 +5,10 @@ from maxo.dialogs.api.entities import Context, Stack
 from maxo.dialogs.api.protocols import StackAccessValidator
 from maxo.enums import ChatType
 from maxo.routing.ctx import Ctx
-from maxo.routing.middlewares.update_context import EVENT_CHAT_KEY, EVENT_FROM_USER_KEY
+from maxo.routing.middlewares.update_context import (
+    EVENT_FROM_USER_KEY,
+    UPDATE_CONTEXT_KEY,
+)
 
 logger = getLogger(__name__)
 
@@ -22,9 +25,10 @@ class DefaultAccessValidator(StackAccessValidator):
 
         if not access_settings:
             return True
-        chat = ctx.get(EVENT_CHAT_KEY)
-        # У maxo нет ChatType.PRIVATE, аналог - ChatType.DIALOG
-        if chat is not None and chat.type is ChatType.DIALOG:
+        update_context = ctx.get(UPDATE_CONTEXT_KEY)
+        # У maxo нет ChatType.PRIVATE, аналог - ChatType.DIALOG.
+        # UpdateContext есть всегда, EVENT_CHAT_KEY - только при enrich=True.
+        if update_context is not None and update_context.chat_type is ChatType.DIALOG:
             return True
         if access_settings.user_ids:
             user = ctx.get(EVENT_FROM_USER_KEY)

--- a/src/maxo/dialogs/context/access_validator.py
+++ b/src/maxo/dialogs/context/access_validator.py
@@ -3,9 +3,9 @@ from logging import getLogger
 from maxo.dialogs import ChatEvent
 from maxo.dialogs.api.entities import Context, Stack
 from maxo.dialogs.api.protocols import StackAccessValidator
+from maxo.enums import ChatType
 from maxo.routing.ctx import Ctx
-from maxo.routing.middlewares.update_context import EVENT_FROM_USER_KEY
-from maxo.types import User
+from maxo.routing.middlewares.update_context import EVENT_CHAT_KEY, EVENT_FROM_USER_KEY
 
 logger = getLogger(__name__)
 
@@ -20,18 +20,15 @@ class DefaultAccessValidator(StackAccessValidator):
     ) -> bool:
         access_settings = context.access_settings if context else stack.access_settings
 
-        # if everything is disabled, it is allowed
-        if access_settings is None:
+        if not access_settings:
             return True
-        if not (access_settings.user_ids or access_settings.custom):
+        chat = ctx.get(EVENT_CHAT_KEY)
+        # У maxo нет ChatType.PRIVATE, аналог - ChatType.DIALOG
+        if chat is not None and chat.type is ChatType.DIALOG:
             return True
-
-        user: User | None = ctx.get(EVENT_FROM_USER_KEY)
-        # Если access требует user_ids а user отсутствует (например, пост в канале)
-        # - доступ запрещён, AttributeError быть не должен
-        if user is None:
-            return False
-        if user.id in access_settings.user_ids:  # noqa: SIM103
-            return True
-
-        return False
+        if access_settings.user_ids:
+            user = ctx.get(EVENT_FROM_USER_KEY)
+            # Пост в канале без user - не пройдёт user_ids, но не AttributeError
+            if user is None or user.id not in access_settings.user_ids:
+                return False
+        return True

--- a/src/maxo/dialogs/context/intent_middleware.py
+++ b/src/maxo/dialogs/context/intent_middleware.py
@@ -170,7 +170,7 @@ class IntentMiddlewareFactory:
             storage=fsm_storage,
             events_isolation=self.events_isolation,
             state_groups=self.registry.states_groups(),
-            user_id=event_context.user.id,
+            user_id=event_context.user_id,
             chat_id=event_context.chat_id,
             chat_type=event_context.chat_type,
         )
@@ -570,7 +570,7 @@ class IntentErrorMiddleware(BaseMiddleware[ErrorEvent]):
                 storage=ctx[FSM_STORAGE_KEY],
                 events_isolation=self.events_isolation,
                 state_groups=self.registry.states_groups(),
-                user_id=event_context.user.id,
+                user_id=event_context.user_id,
                 chat_id=event_context.chat_id,
                 chat_type=event_context.chat_type,
             )

--- a/src/maxo/dialogs/test_tools/bot_client.py
+++ b/src/maxo/dialogs/test_tools/bot_client.py
@@ -167,6 +167,7 @@ class BotClient:
 
     async def send_channel_message_edited(self, text: str, mid: str) -> Any:
         """Эмулирует MessageEdited в канале без sender."""
+        seq = int(mid) if mid.isdigit() else self._new_message_id()
         msg = Message(
             recipient=Recipient(
                 chat_type=ChatType.CHANNEL,
@@ -174,7 +175,7 @@ class BotClient:
                 chat_id=self.chat.chat_id,
             ),
             timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
-            body=MessageBody(mid=mid, seq=int(mid), text=text),
+            body=MessageBody(mid=mid, seq=seq, text=text),
             stat=MessageStat(views=1),
             url="https://max.ru/",
         )

--- a/src/maxo/dialogs/test_tools/bot_client.py
+++ b/src/maxo/dialogs/test_tools/bot_client.py
@@ -11,6 +11,8 @@ from maxo.routing.updates import (
     BotAddedToChat,
     MessageCallback,
     MessageCreated,
+    MessageEdited,
+    MessageRemoved,
     UserAddedToChat,
 )
 from maxo.types import (
@@ -129,6 +131,72 @@ class BotClient:
                     message=self._new_message(text, reply_to),
                     timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
                     user_locale="ru",
+                ),
+            ),
+            self.bot,
+        )
+
+    async def send_channel_post(self, text: str) -> Any:
+        """Эмулирует пост в канале: MessageCreated без sender (бот-админ)."""
+        message_seq = self._new_message_id()
+        msg = Message(
+            recipient=Recipient(
+                chat_type=ChatType.CHANNEL,
+                user_id=self.bot.state.info.user_id,
+                chat_id=self.chat.chat_id,
+            ),
+            timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
+            body=MessageBody(
+                mid=str(message_seq),
+                seq=message_seq,
+                text=text,
+            ),
+            stat=MessageStat(views=1),
+            url="https://max.ru/",
+        )
+        return await self.dp.feed_update(
+            MaxoUpdate(
+                update=MessageCreated(
+                    message=msg,
+                    timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
+                    user_locale="ru",
+                ),
+            ),
+            self.bot,
+        )
+
+    async def send_channel_message_edited(self, text: str, mid: str) -> Any:
+        """Эмулирует MessageEdited в канале без sender."""
+        msg = Message(
+            recipient=Recipient(
+                chat_type=ChatType.CHANNEL,
+                user_id=self.bot.state.info.user_id,
+                chat_id=self.chat.chat_id,
+            ),
+            timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
+            body=MessageBody(mid=mid, seq=int(mid), text=text),
+            stat=MessageStat(views=1),
+            url="https://max.ru/",
+        )
+        return await self.dp.feed_update(
+            MaxoUpdate(
+                update=MessageEdited(
+                    message=msg,
+                    timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
+                ),
+            ),
+            self.bot,
+        )
+
+    async def send_channel_message_removed(self, mid: str) -> Any:
+        """Эмулирует MessageRemoved в канале без sender."""
+        return await self.dp.feed_update(
+            MaxoUpdate(
+                update=MessageRemoved(
+                    message_id=mid,
+                    chat_id=self.chat.chat_id,
+                    user_id=self.bot.state.info.user_id,
+                    timestamp=datetime.fromtimestamp(1234567890, tz=UTC),
                 ),
             ),
             self.bot,

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -59,3 +59,20 @@ async def test_storage_proxy_channel_message_created(
     assert ev_ctx.user_id is None
     assert ev_ctx.chat_id == -100
     assert ev_ctx.chat_type == ChatType.CHANNEL
+
+
+@pytest.mark.asyncio
+async def test_storage_proxy_channel_message_edited(
+    channel_client: BotClient,
+) -> None:
+    """MessageEdited без sender тоже не падает (smoke - feed_update не кидает AttributeError)."""
+    await channel_client.send_channel_message_edited("Edited", mid="42")
+
+
+@pytest.mark.asyncio
+async def test_storage_proxy_channel_message_removed(
+    channel_client: BotClient,
+    captured_ctx: dict[str, Any],
+) -> None:
+    """MessageRemoved без user тоже не падает."""
+    await channel_client.send_channel_message_removed(mid="42")

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -1,5 +1,4 @@
 """Тесты обработки сообщений из каналов (без sender.user) - закрывает issue #111."""
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -13,7 +12,11 @@ from maxo.dialogs.test_tools import BotClient, MockMessageManager
 from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
 from maxo.enums import ChatType
 from maxo.fsm.key_builder import DefaultKeyBuilder
-from maxo.routing.middlewares.update_context import EVENT_CHAT_KEY, EVENT_FROM_USER_KEY
+from maxo.routing.middlewares.update_context import (
+    EVENT_FROM_USER_KEY,
+    UPDATE_CONTEXT_KEY,
+)
+from maxo.types.update_context import UpdateContext
 
 
 @pytest.fixture
@@ -116,7 +119,7 @@ async def test_access_validator_allows_in_dialog_chat() -> None:
         access_settings=AccessSettings(user_ids=[999]),
     )
     ctx: dict = {
-        EVENT_CHAT_KEY: SimpleNamespace(type=ChatType.DIALOG),
+        UPDATE_CONTEXT_KEY: UpdateContext(type=ChatType.DIALOG),
         EVENT_FROM_USER_KEY: None,
     }
 
@@ -134,7 +137,7 @@ async def test_access_validator_denies_when_user_required_but_missing() -> None:
         access_settings=AccessSettings(user_ids=[1, 2, 3]),
     )
     ctx: dict = {
-        EVENT_CHAT_KEY: SimpleNamespace(type=ChatType.CHANNEL),
+        UPDATE_CONTEXT_KEY: UpdateContext(type=ChatType.CHANNEL),
         EVENT_FROM_USER_KEY: None,
     }
 

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -4,12 +4,15 @@ from typing import Any
 import pytest
 
 from maxo import Dispatcher, Router
-from maxo.dialogs.api.entities import EventContext
+from maxo.dialogs import setup_dialogs
+from maxo.dialogs.api.entities import AccessSettings, EventContext, Stack
 from maxo.dialogs.api.entities.events import EVENT_CONTEXT_KEY
+from maxo.dialogs.context.access_validator import DefaultAccessValidator
 from maxo.dialogs.test_tools import BotClient, MockMessageManager
 from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
 from maxo.enums import ChatType
 from maxo.fsm.key_builder import DefaultKeyBuilder
+from maxo.routing.middlewares.update_context import EVENT_FROM_USER_KEY
 
 
 @pytest.fixture
@@ -24,8 +27,6 @@ def message_manager() -> MockMessageManager:
 
 @pytest.fixture
 def dp(message_manager: MockMessageManager, captured_ctx: dict[str, Any]) -> Dispatcher:
-    from maxo.dialogs import setup_dialogs
-
     router = Router()
 
     @router.message_created()
@@ -91,11 +92,6 @@ async def test_event_context_user_none_visible_in_handler(
     assert ev_ctx.user is None
     assert ev_ctx.user_id is None
     assert ev_ctx.chat_id == -100
-
-
-from maxo.dialogs.api.entities import AccessSettings, Stack
-from maxo.dialogs.context.access_validator import DefaultAccessValidator
-from maxo.routing.middlewares.update_context import EVENT_FROM_USER_KEY
 
 
 @pytest.mark.asyncio

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -91,3 +91,35 @@ async def test_event_context_user_none_visible_in_handler(
     assert ev_ctx.user is None
     assert ev_ctx.user_id is None
     assert ev_ctx.chat_id == -100
+
+
+from maxo.dialogs.api.entities import AccessSettings, Stack
+from maxo.dialogs.context.access_validator import DefaultAccessValidator
+from maxo.routing.middlewares.update_context import EVENT_FROM_USER_KEY
+
+
+@pytest.mark.asyncio
+async def test_access_validator_allows_when_no_settings() -> None:
+    """Если access_settings отсутствуют - доступ разрешён даже без user."""
+    validator = DefaultAccessValidator()
+    stack = Stack(_id="default", access_settings=None)
+    ctx: dict = {EVENT_FROM_USER_KEY: None}
+
+    allowed = await validator.is_allowed(stack=stack, context=None, event=None, ctx=ctx)
+
+    assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_access_validator_denies_when_user_required_but_missing() -> None:
+    """Если access_settings требует user_ids а user=None - доступ запрещён (не AttributeError)."""
+    validator = DefaultAccessValidator()
+    stack = Stack(
+        _id="default",
+        access_settings=AccessSettings(user_ids=[1, 2, 3]),
+    )
+    ctx: dict = {EVENT_FROM_USER_KEY: None}
+
+    allowed = await validator.is_allowed(stack=stack, context=None, event=None, ctx=ctx)
+
+    assert allowed is False

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -1,4 +1,5 @@
 """Тесты обработки сообщений из каналов (без sender.user) - закрывает issue #111."""
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -12,7 +13,7 @@ from maxo.dialogs.test_tools import BotClient, MockMessageManager
 from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
 from maxo.enums import ChatType
 from maxo.fsm.key_builder import DefaultKeyBuilder
-from maxo.routing.middlewares.update_context import EVENT_FROM_USER_KEY
+from maxo.routing.middlewares.update_context import EVENT_CHAT_KEY, EVENT_FROM_USER_KEY
 
 
 @pytest.fixture
@@ -107,14 +108,35 @@ async def test_access_validator_allows_when_no_settings() -> None:
 
 
 @pytest.mark.asyncio
+async def test_access_validator_allows_in_dialog_chat() -> None:
+    """В приватном чате (DIALOG) доступ разрешён даже при заданных user_ids."""
+    validator = DefaultAccessValidator()
+    stack = Stack(
+        _id="default",
+        access_settings=AccessSettings(user_ids=[999]),
+    )
+    ctx: dict = {
+        EVENT_CHAT_KEY: SimpleNamespace(type=ChatType.DIALOG),
+        EVENT_FROM_USER_KEY: None,
+    }
+
+    allowed = await validator.is_allowed(stack=stack, context=None, event=None, ctx=ctx)
+
+    assert allowed is True
+
+
+@pytest.mark.asyncio
 async def test_access_validator_denies_when_user_required_but_missing() -> None:
-    """Если access_settings требует user_ids а user=None - доступ запрещён (не AttributeError)."""
+    """В канале без user и при заданных user_ids - доступ запрещён (не AttributeError)."""
     validator = DefaultAccessValidator()
     stack = Stack(
         _id="default",
         access_settings=AccessSettings(user_ids=[1, 2, 3]),
     )
-    ctx: dict = {EVENT_FROM_USER_KEY: None}
+    ctx: dict = {
+        EVENT_CHAT_KEY: SimpleNamespace(type=ChatType.CHANNEL),
+        EVENT_FROM_USER_KEY: None,
+    }
 
     allowed = await validator.is_allowed(stack=stack, context=None, event=None, ctx=ctx)
 

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -3,11 +3,13 @@ from typing import Any
 
 import pytest
 
+from maxo import Dispatcher, Router
 from maxo.dialogs.api.entities import EventContext
 from maxo.dialogs.api.entities.events import EVENT_CONTEXT_KEY
 from maxo.dialogs.test_tools import BotClient, MockMessageManager
+from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
 from maxo.enums import ChatType
-from maxo import Dispatcher, Router
+from maxo.fsm.key_builder import DefaultKeyBuilder
 
 
 @pytest.fixture
@@ -30,7 +32,10 @@ def dp(message_manager: MockMessageManager, captured_ctx: dict[str, Any]) -> Dis
     async def handler(event, ctx):
         captured_ctx["event_context"] = ctx[EVENT_CONTEXT_KEY]
 
-    dp = Dispatcher()
+    dp = Dispatcher(
+        storage=JsonMemoryStorage(),
+        key_builder=DefaultKeyBuilder(with_destiny=True),
+    )
     dp.include_router(router)
     setup_dialogs(dp, message_manager=message_manager)
     return dp

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -1,0 +1,56 @@
+"""Тесты обработки сообщений из каналов (без sender.user) - закрывает issue #111."""
+from typing import Any
+
+import pytest
+
+from maxo.dialogs.api.entities import EventContext
+from maxo.dialogs.api.entities.events import EVENT_CONTEXT_KEY
+from maxo.dialogs.test_tools import BotClient, MockMessageManager
+from maxo.enums import ChatType
+from maxo import Dispatcher, Router
+
+
+@pytest.fixture
+def captured_ctx() -> dict[str, Any]:
+    return {}
+
+
+@pytest.fixture
+def message_manager() -> MockMessageManager:
+    return MockMessageManager()
+
+
+@pytest.fixture
+def dp(message_manager: MockMessageManager, captured_ctx: dict[str, Any]) -> Dispatcher:
+    from maxo.dialogs import setup_dialogs
+
+    router = Router()
+
+    @router.message_created()
+    async def handler(event, ctx):
+        captured_ctx["event_context"] = ctx[EVENT_CONTEXT_KEY]
+
+    dp = Dispatcher()
+    dp.include_router(router)
+    setup_dialogs(dp, message_manager=message_manager)
+    return dp
+
+
+@pytest.fixture
+def channel_client(dp: Dispatcher) -> BotClient:
+    return BotClient(dp, user_id=1, chat_id=-100, chat_type=ChatType.CHANNEL)
+
+
+@pytest.mark.asyncio
+async def test_storage_proxy_channel_message_created(
+    channel_client: BotClient,
+    captured_ctx: dict[str, Any],
+) -> None:
+    """MessageCreated без sender.user не должен падать в storage_proxy."""
+    await channel_client.send_channel_post("Привет канал")
+
+    ev_ctx: EventContext = captured_ctx["event_context"]
+    assert ev_ctx.user is None
+    assert ev_ctx.user_id is None
+    assert ev_ctx.chat_id == -100
+    assert ev_ctx.chat_type == ChatType.CHANNEL

--- a/tests/maxo_dialog/test_channel_messages.py
+++ b/tests/maxo_dialog/test_channel_messages.py
@@ -76,3 +76,18 @@ async def test_storage_proxy_channel_message_removed(
 ) -> None:
     """MessageRemoved без user тоже не падает."""
     await channel_client.send_channel_message_removed(mid="42")
+
+
+@pytest.mark.asyncio
+async def test_event_context_user_none_visible_in_handler(
+    channel_client: BotClient,
+    captured_ctx: dict[str, Any],
+) -> None:
+    """Хендлер видит EventContext с user=None при channel-посте."""
+    await channel_client.send_channel_post("end-to-end")
+
+    ev_ctx: EventContext = captured_ctx["event_context"]
+    assert ev_ctx.bot is not None
+    assert ev_ctx.user is None
+    assert ev_ctx.user_id is None
+    assert ev_ctx.chat_id == -100


### PR DESCRIPTION
Closes #111

## Что чинит

`AttributeError: 'NoneType' object has no attribute 'id'` в `IntentMiddlewareFactory.storage_proxy` (и в `IntentErrorMiddleware`) при channel-сообщениях где `event.message.sender` отсутствует (бот-админ канала с `read_all_messages`).

## Изменения

1. **`intent_middleware.py:173` и `:573`** - `event_context.user.id` -> `event_context.user_id` в двух местах: `IntentMiddlewareFactory.storage_proxy` и `IntentErrorMiddleware.storage_proxy` (тот же баг в error-handling пути). `EventContext.user_id` уже корректно вычисляется в `event_context_from_message` как `(sender.user_id or user.user_id)`. `StorageProxy.__init__` принимает `user_id: int | None` - chat-scoped FSM корректно работает без user.

2. **`access_validator.py`** - `DefaultAccessValidator.is_allowed` теперь не падает когда `EVENT_FROM_USER_KEY=None`. Если `access_settings` требует user_ids а user отсутствует - возвращаем False (доступ запрещён, что является корректным поведением для канала). Изменено с `ctx[EVENT_FROM_USER_KEY]` на `ctx.get(...)` + guard.

   Расхождение с [оригиналом aiogram_dialog](https://github.com/Tishka17/aiogram_dialog/blob/cb4179147e1498f5d3c0989f34557e8d5a9d2943/src/aiogram_dialog/context/access_validator.py#L15-L37): там user тоже без guards, но в Telegram private/group чатах user всегда есть. В MAX каналах - нет.

## Тесты

Новый файл `tests/maxo_dialog/test_channel_messages.py` (6 тестов):
- `test_storage_proxy_channel_message_created` - канальный пост через storage_proxy не падает
- `test_storage_proxy_channel_message_edited` - редактирование тоже
- `test_storage_proxy_channel_message_removed` - удаление тоже
- `test_event_context_user_none_visible_in_handler` - e2e через BotClient
- `test_access_validator_allows_when_no_settings` - sanity
- `test_access_validator_denies_when_user_required_but_missing` - регрессия на AttributeError

Расширен `BotClient` методами `send_channel_post`, `send_channel_message_edited`, `send_channel_message_removed` для эмуляции channel-сценариев без `sender`.

## Production-impact

В `max-reposter` падало на каждом из ~11 каналов на каждый пост. После фикса - смокается, все 6 тестов зелёные, регрессий в существующих 343 тестах нет (итого 349 passed, 1 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Уточнено поведение проверки доступа: при пустых настройках доступ разрешается; диалоги пропускаются при наличии контекста обновления; отказ по пользователю применяется только если задан список user_ids.
  * Исправлено формирование идентификатора пользователя для механизмов хранения в обычной и аварийной обработке.

* **Тесты**
  * Добавлены тесты обработки сообщений в каналах (создание, правка, удаление) без отправителя.
  * Расширены тестовые утилиты для имитации событий жизненного цикла каналов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->