### PR TITLE
perf(dialogs): defer show() в start/done из callback-контекста (DRAFT)

### DIFF
--- a/src/maxo/dialogs/dialog.py
+++ b/src/maxo/dialogs/dialog.py
@@ -170,6 +170,7 @@ class Dialog(Router, DialogProtocol):
         window = await self._current_window(dialog_manager)
         impl = cast(ManagerImpl, dialog_manager)
         impl._defer_show = True  # noqa: SLF001
+        pending = False
         try:
             try:
                 processed = await window.process_callback(
@@ -179,11 +180,13 @@ class Dialog(Router, DialogProtocol):
                 )
             except CancelEventProcessing:
                 processed = False
+            pending = impl._pending_show  # noqa: SLF001
         finally:
+            # Сброс в finally чтобы исключение из process_callback не оставило
+            # _pending_show=True для следующего callback на том же ManagerImpl
             impl._defer_show = False  # noqa: SLF001
+            impl._pending_show = False  # noqa: SLF001
 
-        pending = impl._pending_show  # noqa: SLF001
-        impl._pending_show = False  # noqa: SLF001
         need_refresh = self._need_refresh(processed, old_context, dialog_manager)
 
         tasks: list[Awaitable[Any]] = [dialog_manager.answer_callback()]

--- a/src/maxo/dialogs/dialog.py
+++ b/src/maxo/dialogs/dialog.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 from collections.abc import Awaitable, Callable
 from logging import getLogger
@@ -5,6 +6,7 @@ from typing import (
     Any,
     ParamSpec,
     TypeVar,
+    cast,
 )
 
 from maxo import Router
@@ -25,6 +27,7 @@ from maxo.routing.updates import MessageCallback, MessageCreated
 from maxo.types.update_context import UpdateContext
 
 from .context.intent_filter import IntentFilter
+from .manager.manager import ManagerImpl
 from .utils import remove_intent_id
 from .widgets.data import PreviewAwareGetter
 from .widgets.utils import GetterVariant, ensure_data_getter
@@ -165,17 +168,28 @@ class Dialog(Router, DialogProtocol):
         cleaned_event = dataclasses.replace(callback, callback=cleaned_callback)
 
         window = await self._current_window(dialog_manager)
+        impl = cast(ManagerImpl, dialog_manager)
+        impl._defer_show = True  # noqa: SLF001
         try:
-            processed = await window.process_callback(
-                cleaned_event,
-                self,
-                dialog_manager,
-            )
-        except CancelEventProcessing:
-            processed = False
-        if self._need_refresh(processed, old_context, dialog_manager):
-            await dialog_manager.show()
-        await dialog_manager.answer_callback()
+            try:
+                processed = await window.process_callback(
+                    cleaned_event,
+                    self,
+                    dialog_manager,
+                )
+            except CancelEventProcessing:
+                processed = False
+        finally:
+            impl._defer_show = False  # noqa: SLF001
+
+        pending = impl._pending_show  # noqa: SLF001
+        impl._pending_show = False  # noqa: SLF001
+        need_refresh = self._need_refresh(processed, old_context, dialog_manager)
+
+        tasks: list[Awaitable[Any]] = [dialog_manager.answer_callback()]
+        if need_refresh or pending:
+            tasks.append(dialog_manager.show())
+        await asyncio.gather(*tasks)
 
     def _need_refresh(
         self,

--- a/src/maxo/dialogs/manager/manager.py
+++ b/src/maxo/dialogs/manager/manager.py
@@ -206,7 +206,10 @@ class ManagerImpl(DialogManager):
         await dialog.process_result(old_context.start_data, result, self)
         new_context = self._current_context_unsafe()
         if new_context and context.id == new_context.id:
-            await self.show(show_mode)
+            if self._defer_show:
+                self._pending_show = True
+            else:
+                await self.show(show_mode)
 
     async def answer_callback(self) -> None:
         if not isinstance(self.event, MessageCallback):
@@ -306,7 +309,10 @@ class ManagerImpl(DialogManager):
         await self.dialog().process_start(self, data, state)
         new_context = self._current_context_unsafe()
         if new_context and context.id == new_context.id:
-            await self.show()
+            if self._defer_show:
+                self._pending_show = True
+            else:
+                await self.show()
 
     async def _process_launch_mode(
         self,

--- a/src/maxo/dialogs/manager/manager.py
+++ b/src/maxo/dialogs/manager/manager.py
@@ -79,6 +79,8 @@ class ManagerImpl(DialogManager):
         self._registry = registry
         self._router = router
         self._getter = getter
+        self._defer_show: bool = False
+        self._pending_show: bool = False
 
     @property
     def show_mode(self) -> ShowMode:

--- a/tests/maxo_dialog/test_defer_show.py
+++ b/tests/maxo_dialog/test_defer_show.py
@@ -33,3 +33,93 @@ async def test_start_inside_callback_defers_show() -> None:
 
     mgr.show.assert_not_called()
     assert mgr._pending_show is True
+
+
+@pytest.mark.asyncio
+async def test_start_outside_callback_renders_immediately() -> None:
+    """_start_normal вне callback (defer_show=False) рендерит сразу через show()."""
+    mgr = MagicMock(spec=ManagerImpl)
+    mgr._defer_show = False
+    mgr._pending_show = False
+    mgr.show = AsyncMock()
+    mgr.has_context = MagicMock(return_value=False)
+    mgr._registry = MagicMock()
+    mgr._registry.find_dialog = MagicMock(return_value=MagicMock(launch_mode=MagicMock()))
+    mgr._process_launch_mode = AsyncMock()
+    mgr._ctx = {}
+    mgr.storage = MagicMock(return_value=AsyncMock())
+
+    stack = MagicMock()
+    stack.empty = MagicMock(return_value=True)
+    stack.access_settings = None
+    new_ctx = MagicMock()
+    new_ctx.id = "ctx_id"
+    stack.push = MagicMock(return_value=new_ctx)
+    mgr.current_stack = MagicMock(return_value=stack)
+    mgr.dialog = MagicMock(return_value=MagicMock(process_start=AsyncMock()))
+    mgr._current_context_unsafe = MagicMock(return_value=new_ctx)
+
+    await ManagerImpl._start_normal(mgr, state=MagicMock(), data=None, access_settings=None)
+
+    mgr.show.assert_awaited_once()
+    assert mgr._pending_show is False
+
+
+@pytest.mark.asyncio
+async def test_done_inside_callback_defers_show() -> None:
+    """done() из callback (defer_show=True) тоже откладывает show."""
+    mgr = MagicMock(spec=ManagerImpl)
+    mgr._defer_show = True
+    mgr._pending_show = False
+    mgr.show = AsyncMock()
+    mgr.show_mode = MagicMock()
+    mgr.check_disabled = MagicMock()
+    mgr.mark_closed = AsyncMock()
+
+    old_context = MagicMock()
+    old_context.id = "old_id"
+    old_context.start_data = None
+    same_context = MagicMock()
+    same_context.id = "old_id"
+
+    mgr.current_context = MagicMock(return_value=old_context)
+    mgr._current_context_unsafe = MagicMock(return_value=same_context)
+    mgr.dialog = MagicMock(return_value=MagicMock(
+        process_close=AsyncMock(),
+        process_result=AsyncMock(),
+    ))
+
+    await ManagerImpl.done(mgr, result=None, show_mode=None)
+
+    mgr.show.assert_not_called()
+    assert mgr._pending_show is True
+
+
+@pytest.mark.asyncio
+async def test_done_outside_callback_renders_immediately() -> None:
+    """done() вне callback (defer_show=False) рендерит сразу."""
+    mgr = MagicMock(spec=ManagerImpl)
+    mgr._defer_show = False
+    mgr._pending_show = False
+    mgr.show = AsyncMock()
+    mgr.show_mode = MagicMock()
+    mgr.check_disabled = MagicMock()
+    mgr.mark_closed = AsyncMock()
+
+    old_context = MagicMock()
+    old_context.id = "old_id"
+    old_context.start_data = None
+    same_context = MagicMock()
+    same_context.id = "old_id"
+
+    mgr.current_context = MagicMock(return_value=old_context)
+    mgr._current_context_unsafe = MagicMock(return_value=same_context)
+    mgr.dialog = MagicMock(return_value=MagicMock(
+        process_close=AsyncMock(),
+        process_result=AsyncMock(),
+    ))
+
+    await ManagerImpl.done(mgr, result=None, show_mode=None)
+
+    mgr.show.assert_awaited_once()
+    assert mgr._pending_show is False

--- a/tests/maxo_dialog/test_defer_show.py
+++ b/tests/maxo_dialog/test_defer_show.py
@@ -1,0 +1,35 @@
+"""Тесты отложенного render в manager.start/done из callback - закрывает п.3 issue #110."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from maxo.dialogs.manager.manager import ManagerImpl
+
+
+@pytest.mark.asyncio
+async def test_start_inside_callback_defers_show() -> None:
+    """_start_normal в режиме defer не зовёт show, ставит _pending_show=True."""
+    mgr = MagicMock(spec=ManagerImpl)
+    mgr._defer_show = True
+    mgr._pending_show = False
+    mgr.show = AsyncMock()
+    mgr.has_context = MagicMock(return_value=False)
+    mgr._registry = MagicMock()
+    mgr._registry.find_dialog = MagicMock(return_value=MagicMock(launch_mode=MagicMock()))
+    mgr._process_launch_mode = AsyncMock()
+    mgr._ctx = {}
+
+    stack = MagicMock()
+    stack.empty = MagicMock(return_value=True)
+    stack.access_settings = None
+    new_ctx = MagicMock()
+    new_ctx.id = "ctx_id"
+    stack.push = MagicMock(return_value=new_ctx)
+    mgr.current_stack = MagicMock(return_value=stack)
+    mgr.dialog = MagicMock(return_value=MagicMock(process_start=AsyncMock()))
+    mgr._current_context_unsafe = MagicMock(return_value=new_ctx)
+
+    await ManagerImpl._start_normal(mgr, state=MagicMock(), data=None, access_settings=None)
+
+    mgr.show.assert_not_called()
+    assert mgr._pending_show is True


### PR DESCRIPTION
Refs #110 (п.3)

> 🚧 **DRAFT** - для обсуждения подхода до commit'а в API. Готов развернуть дизайн (например на `contextvars` вместо атрибутов на `ManagerImpl`).

## Проблема

Текущий поток для `Start`/`Cancel` widget на каллбэк:

```
_callback_handler -> process_callback -> on_click -> manager.start()
                                                     |- await self.show()  # PUT /messages здесь
                                       <- возврат, context уже новый
  _need_refresh() -> False (context сменился, но show уже произошёл)
  gather (из п.2): [answer_callback()]    # show() не попадает в gather
  POST /answers                           # +RTT
```

Итог: оптимизация п.2 (`asyncio.gather` показа и ответа на callback, см. PR #114) **не работает** для основных навигационных кнопок (`Start`, `Cancel`, и любая `SwitchTo` на новый стек). Замер: `SwitchTo`/`Back` улучшилось 720 -> 280ms, `Start`/`Cancel` так и остаётся ~510ms.

## Решение (PoC)

Режим отложенного render, активный **только** когда `start/done` вызываются изнутри `_callback_handler`. Не меняет поведение для других сценариев (background tasks, message handlers, nested dialogs из non-callback контекста).

1. `ManagerImpl.__init__`: добавлены `self._defer_show: bool = False` и `self._pending_show: bool = False`.
2. `done()` / `_start_normal()`: `await self.show(...)` -> `if self._defer_show: self._pending_show = True; else: await self.show(...)`.
3. `Dialog._callback_handler`: оборачивает `process_callback` в `try/finally` с выставлением `_defer_show = True`. После - в `asyncio.gather` добавляет `show()` если `_need_refresh()` ИЛИ `_pending_show`.

## Замеры (ожидаемые)

| Кнопка | До | +п.1 | +п.1+п.2 | +п.1+п.2+п.3 |
|---|---|---|---|---|
| `SwitchTo`/`Back` | 720ms | 510ms | **280ms** | 280ms |
| `Start`/`Cancel` | 720ms | 510ms | 510ms | **280ms** |

(Реальные замеры с продакшена `max-reposter` после мерджа волны 1+2 - добавлю в этот PR.)

## Тесты

`tests/maxo_dialog/test_defer_show.py` (4 теста):
- `test_start_inside_callback_defers_show` - флаг ставится, show не зовётся синхронно
- `test_start_outside_callback_renders_immediately` - регрессия: НЕ ломает обычный сценарий
- `test_done_inside_callback_defers_show` - симметрично для Cancel
- `test_done_outside_callback_renders_immediately` - симметричная регрессия

Полная регрессия: 347 passed (343 baseline + 4 новых), 0 регрессий. Ruff чистый.

## Открытые вопросы для обсуждения

1. **Атрибуты на ManagerImpl vs contextvars.** Сейчас флаги `_defer_show`/`_pending_show` хранятся как атрибуты на `ManagerImpl`. Альтернатива: `_DEFER_SHOW: ContextVar[bool]` модульного уровня в `dialog.py`, без изменения класса. Чище в плане API, но менее очевидно при дебаге.

2. **`cast(ManagerImpl, dialog_manager)` в dialog.py.** Сейчас в `_callback_handler` я делаю `cast` потому что `DialogManager` (Protocol) не объявляет эти флаги. Альтернатива: добавить `_defer_show`/`_pending_show` в Protocol как абстрактные property (с setters). Это расширяет publi API, но без cast'а.

3. **Re: nested dialogs.** Покрыто unit-тестами на `_start_normal` / `done()`. Интеграционный nested-test не написан (BotClient setup tricky), но логически: каждый callback - своя итерация флага, `_pending_show` сбрасывается после gather, нет накопления состояния.

4. **Зависимость от PR #114.** Этот патч включает И gather (п.2), И defer-логику (п.3). Если PR #114 (`feature/parallel-callback-answer`) смержится первым - я ребейзнусь и оставлю тут только defer. Если этот мерджишь первым - PR #114 закроется (поглощён).

Готов адаптировать под фидбек.