### PR TITLE
fix: justfile duplicate recipe error on windows

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -19,6 +19,7 @@ ruff:
 codespell:
     codespell src examples
 
+[unix]
 slots:
     PYTHONPATH=src slotscheck -m maxo
 


### PR DESCRIPTION
# Описание

just падал с ошибкой "error: recipe slots first defined on line 22 is redefined on line 26" из-за того что видел рецепт slots дважды. Решено добавлением атрибута перед первым slots

## Тип изменения

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Как это было протестировано?

just test

Описание

**Тестовая конфигурация**:
* Операционная система: Windows 10
* Версия Python: 3.12

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [ ] Я внес соответствующие изменения в документацию
- [ ] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код полностью написан мной без использования нейросетей
- [ ] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Техническое обслуживание**
  * Оптимизирована совместимость инструментов разработки с различными операционными системами для корректной работы на Unix и Windows платформах.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/K1rL3s/maxo/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->