### PR TITLE
`ConfirmButton` - кнопка с двойным подтверждением

### DIFF
--- a/docs/pages/dialogs/widgets.rst
+++ b/docs/pages/dialogs/widgets.rst
@@ -192,6 +192,130 @@ Radio
         # В геттере: return {"languages": [("ru", "Русский"), ("en", "English")]}
     )
 
+ConfirmButton
+-------------
+
+Кнопка с двойным подтверждением. При первом нажатии переходит в состояние ожидания - показывает опциональный предупреждающий текст и кнопки «Отмена» / «Подтвердить». При повторном нажатии вызывает соответствующий обработчик.
+
+**Ключевая особенность:** виджет не хранит состояние в данных диалога - оно выводится из payload кнопки. Благодаря этому при переходе в другое окно и обратно кнопка автоматически сбрасывается в исходное (primary) состояние.
+
+Использование
+^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from maxo.dialogs.api.protocols import DialogManager
+    from maxo.dialogs.widgets.kbd import ConfirmButton
+    from maxo.dialogs.widgets.text import Const
+    from maxo.routing.updates import MessageCallback
+
+    async def on_confirm(
+        callback: MessageCallback,
+        widget: ConfirmButton,
+        manager: DialogManager,
+    ) -> None:
+        await callback.message.answer("Действие подтверждено!")
+
+    async def on_cancel(
+        callback: MessageCallback,
+        widget: ConfirmButton,
+        manager: DialogManager,
+    ) -> None:
+        await callback.message.answer("Действие отменено.")
+
+    # Режим с предупредительным текстом (2 шага):
+    # primary → warning + [Отмена] [Подтвердить] → on_confirm / on_cancel
+    ConfirmButton(
+        id="delete_btn",
+        primary_text=Const("🗑 Удалить"),
+        confirm_text=Const("✅ Да, удалить"),
+        cancel_text=Const("❌ Отмена"),
+        warning_text=Const("⚠️ Вы уверены?"),
+        on_confirm=on_confirm,
+        on_cancel=on_cancel,
+    )
+
+    # Режим без предупредительного текста (1 шаг):
+    # primary → [Отмена] [Подтвердить] (без строки с текстом)
+    ConfirmButton(
+        id="buy_btn",
+        primary_text=Const("🛒 Купить"),
+        confirm_text=Const("✅ Купить"),
+        cancel_text=Const("❌ Нет"),
+        warning_text=None,  # строка-предупреждение не отображается
+        on_confirm=on_confirm,
+        on_cancel=None,    # при отмене просто возвращается primary
+    )
+
+Параметры
+^^^^^^^^^
+
+*   **id** (:py:class:`str`): Уникальный идентификатор виджета. Используется для различения нескольких ``ConfirmButton`` в одном окне.
+*   **primary_text** (:py:class:`~maxo.dialogs.api.internal.TextWidget`): Текст кнопки в исходном состоянии.
+*   **confirm_text** (:py:class:`~maxo.dialogs.api.internal.TextWidget`): Текст кнопки подтверждения в состоянии ожидания.
+*   **cancel_text** (:py:class:`~maxo.dialogs.api.internal.TextWidget`): Текст кнопки отмены в состоянии ожидания.
+*   **warning_text** (:py:class:`~maxo.dialogs.api.internal.TextWidget` | ``None``, optional): Текст предупреждения, отображаемый отдельной строкой над кнопками отмены/подтверждения. Если ``None`` - строка не добавляется, кнопки появляются сразу. По умолчанию ``None``.
+*   **on_confirm** (:py:class:`~maxo.dialogs.widgets.kbd.confirm_button.OnClick` | ``None``, optional): Обработчик, вызываемый при нажатии кнопки подтверждения. По умолчанию ``None`` (no-op).
+*   **on_cancel** (:py:class:`~maxo.dialogs.widgets.kbd.confirm_button.OnClick` | ``None``, optional): Обработчик, вызываемый при нажатии кнопки отмены. По умолчанию ``None`` (no-op, виджет возвращается в primary).
+*   **confirm_first** (:py:class:`bool`, optional): Если ``True`` - кнопка подтверждения отображается левее кнопки отмены. По умолчанию ``False`` (порядок: «Отмена» | «Подтвердить»).
+*   **oneline** (:py:class:`bool`, optional): Если ``True`` - кнопки отмены и подтверждения будут в одном ряду, иначе в двух. По умолчанию ``True``
+*   **when** (:py:class:`~maxo.dialogs.widgets.common.WhenCondition`, optional): Условие, при котором виджет отображается. При ``False`` виджет полностью скрывается.
+
+Поведение при переходах между окнами
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ConfirmButton`` намеренно не сохраняет состояние ожидания в данных диалога. Это означает, что при переходе в другое окно (``SwitchTo``, ``Next``, ``Back``) и возврате обратно кнопка всегда отрисовывается в исходном (primary) состоянии. Такое поведение позволяет избежать «зависшего» состояния подтверждения при навигации.
+
+.. code-block:: python
+
+    from maxo.dialogs.widgets.kbd import ConfirmButton, SwitchTo
+    from maxo.dialogs.widgets.text import Const
+
+    # В этом примере при возврате из SG.settings обратно в SG.main
+    # кнопка delete_btn будет снова показана как "🗑 Удалить", а не как
+    # "⚠️ Вы уверены? / [Отмена] [Да, удалить]"
+    Window(
+        Const("Главное меню"),
+        ConfirmButton(
+            id="delete_btn",
+            primary_text=Const("🗑 Удалить"),
+            confirm_text=Const("✅ Да, удалить"),
+            cancel_text=Const("❌ Отмена"),
+            warning_text=Const("⚠️ Вы уверены?"),
+            on_confirm=on_confirm,
+        ),
+        SwitchTo(Const("⚙️ Настройки"), id="to_settings", state=SG.settings),
+        state=SG.main,
+    )
+
+Несколько кнопок в одном окне
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+В одном окне можно разместить несколько ``ConfirmButton`` - они не пересекаются по payload-префиксу, поскольку каждый виджет использует свой уникальный ``id``.
+
+.. code-block:: python
+
+    Window(
+        Const("Выберите заказ:"),
+        ConfirmButton(
+            id="pizza",
+            primary_text=Const("🍕 Заказать пиццу"),
+            confirm_text=Const("✅ Точно"),
+            cancel_text=Const("❌ Передумал"),
+            warning_text=Const("🍕 Подтверди заказ пиццы"),
+            on_confirm=on_pizza,
+            on_cancel=on_pizza_cancel,
+        ),
+        ConfirmButton(
+            id="sushi",
+            primary_text=Const("🍣 Заказать суши"),
+            confirm_text=Const("✅ Точно суши"),
+            cancel_text=Const("❌ Передумал, не суши"),
+            on_confirm=on_sushi,
+        ),
+        state=SG.main,
+    )
+
 TimeSelect
 ----------
 

--- a/examples/dialogs_confirm_button.py
+++ b/examples/dialogs_confirm_button.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+import os
+
+from maxo import Bot, Dispatcher, Router
+from maxo.dialogs import (
+    Dialog,
+    DialogManager,
+    ShowMode,
+    StartMode,
+    Window,
+    setup_dialogs,
+)
+from maxo.dialogs.widgets.kbd import ConfirmButton
+from maxo.dialogs.widgets.text import Const
+from maxo.fsm import State, StatesGroup
+from maxo.fsm.key_builder import DefaultKeyBuilder
+from maxo.fsm.storages.memory import MemoryStorage, SimpleEventIsolation
+from maxo.routing.updates import MessageCallback, MessageCreated
+from maxo.transport.long_polling import LongPolling
+
+
+class SG(StatesGroup):
+    main = State()
+
+
+async def on_confirm_handler(
+    callback: MessageCallback,
+    widget: ConfirmButton,
+    manager: DialogManager,
+) -> None:
+    await callback.message.answer("Action confirmed!")
+    manager.show_mode = ShowMode.SEND
+
+
+async def on_cancel_handler(
+    callback: MessageCallback,
+    widget: ConfirmButton,
+    manager: DialogManager,
+) -> None:
+    await callback.message.answer("Action canceled!")
+    manager.show_mode = ShowMode.SEND
+
+
+confirm_dialog = Dialog(
+    Window(
+        Const("Click at any button to see the confirmation flow"),
+        ConfirmButton(
+            primary_text=Const("Primary 1"),
+            confirm_text=Const("Confirm 1"),
+            cancel_text=Const("Cancel 1"),
+            are_you_sure_text=Const("Are you sure? 1"),
+            id="1",
+            on_confirm=on_confirm_handler,
+            on_cancel=on_cancel_handler,
+        ),
+        ConfirmButton(
+            primary_text=Const("Primary 2"),
+            confirm_text=Const("Confirm 2"),
+            cancel_text=Const("Cancel 2"),
+            are_you_sure_text=Const("Are you sure? 2"),
+            id="2",
+            on_confirm=on_confirm_handler,
+            on_cancel=on_cancel_handler,
+        ),
+        state=SG.main,
+    ),
+)
+
+router = Router()
+
+
+@router.message_created()
+async def start(message: MessageCreated, dialog_manager: DialogManager) -> None:
+    await dialog_manager.start(
+        state=SG.main,
+        mode=StartMode.RESET_STACK,
+        show_mode=ShowMode.SEND,
+    )
+
+
+async def main() -> None:
+    bot = Bot(os.environ["TOKEN"])
+
+    key_builder = DefaultKeyBuilder(with_destiny=True)
+    events_isolation = SimpleEventIsolation(key_builder=key_builder)
+    dp = Dispatcher(
+        storage=MemoryStorage(key_builder=key_builder),
+        events_isolation=events_isolation,
+        key_builder=key_builder,
+    )
+
+    dp.include(router, confirm_dialog)
+    setup_dialogs(dp)
+
+    await LongPolling(dp).start(bot)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    asyncio.run(main())

--- a/examples/dialogs_confirm_button.py
+++ b/examples/dialogs_confirm_button.py
@@ -16,6 +16,7 @@ from maxo.dialogs.widgets.text import Const
 from maxo.fsm import State, StatesGroup
 from maxo.fsm.key_builder import DefaultKeyBuilder
 from maxo.fsm.storages.memory import MemoryStorage, SimpleEventIsolation
+from maxo.routing.filters import CommandStart
 from maxo.routing.updates import MessageCallback, MessageCreated
 from maxo.transport.long_polling import LongPolling
 
@@ -80,7 +81,7 @@ confirm_dialog = Dialog(
 router = Router()
 
 
-@router.message_created()
+@router.message_created(CommandStart())
 async def start(message: MessageCreated, dialog_manager: DialogManager) -> None:
     await dialog_manager.start(
         state=SG.main,

--- a/examples/dialogs_confirm_button.py
+++ b/examples/dialogs_confirm_button.py
@@ -11,7 +11,7 @@ from maxo.dialogs import (
     Window,
     setup_dialogs,
 )
-from maxo.dialogs.widgets.kbd import ConfirmButton
+from maxo.dialogs.widgets.kbd import Button, ConfirmButton
 from maxo.dialogs.widgets.text import Const
 from maxo.fsm import State, StatesGroup
 from maxo.fsm.key_builder import DefaultKeyBuilder
@@ -24,44 +24,54 @@ class SG(StatesGroup):
     main = State()
 
 
-async def on_confirm_handler(
+async def on_pizza(
     callback: MessageCallback,
     widget: ConfirmButton,
     manager: DialogManager,
 ) -> None:
-    await callback.message.answer("Action confirmed!")
+    await callback.message.answer("Пицца заказана, жди курьера 🍕")
     manager.show_mode = ShowMode.SEND
 
 
-async def on_cancel_handler(
+async def on_pizza_cancel(
     callback: MessageCallback,
     widget: ConfirmButton,
     manager: DialogManager,
 ) -> None:
-    await callback.message.answer("Action canceled!")
+    await callback.message.answer("Пицца уже в печи, жаль =(")
+    manager.show_mode = ShowMode.SEND
+
+
+async def on_sushi(
+    callback: MessageCallback,
+    widget: ConfirmButton,
+    manager: DialogManager,
+) -> None:
+    await callback.message.answer("Роллы заказаны, жди рыбу 🐡")
     manager.show_mode = ShowMode.SEND
 
 
 confirm_dialog = Dialog(
     Window(
-        Const("Click at any button to see the confirmation flow"),
+        Const("Нажми на любой заказ, чтобы посмотреть работу ConfirmButton"),
         ConfirmButton(
-            primary_text=Const("Primary 1"),
-            confirm_text=Const("Confirm 1"),
-            cancel_text=Const("Cancel 1"),
-            are_you_sure_text=Const("Are you sure? 1"),
-            id="1",
-            on_confirm=on_confirm_handler,
-            on_cancel=on_cancel_handler,
+            primary_text=Const("🍕 Заказать пиццу"),
+            confirm_text=Const("✅ Точно"),
+            cancel_text=Const("❌ Передумал"),
+            warning_text=Const("🍕 Подтверди заказ пиццы"),
+            on_confirm=on_pizza,
+            on_cancel=on_pizza_cancel,
+            id="pizza",
         ),
+        Button(Const("-"), id="empty"),
         ConfirmButton(
-            primary_text=Const("Primary 2"),
-            confirm_text=Const("Confirm 2"),
-            cancel_text=Const("Cancel 2"),
-            are_you_sure_text=Const("Are you sure? 2"),
-            id="2",
-            on_confirm=on_confirm_handler,
-            on_cancel=on_cancel_handler,
+            primary_text=Const("🍣 Заказать суши"),
+            confirm_text=Const("✅ Точно суши"),
+            cancel_text=Const("❌ Передумал, не суши"),
+            warning_text=None,
+            on_confirm=on_sushi,
+            on_cancel=None,
+            id="sushi",
         ),
         state=SG.main,
     ),
@@ -80,7 +90,7 @@ async def start(message: MessageCreated, dialog_manager: DialogManager) -> None:
 
 
 async def main() -> None:
-    bot = Bot(os.environ["TOKEN"])
+    bot = Bot(os.environ["TOKEN"], warming_up=not __debug__)
 
     key_builder = DefaultKeyBuilder(with_destiny=True)
     events_isolation = SimpleEventIsolation(key_builder=key_builder)

--- a/src/maxo/dialogs/api/internal/widgets.py
+++ b/src/maxo/dialogs/api/internal/widgets.py
@@ -12,14 +12,7 @@ from maxo.dialogs.api.entities import MarkupVariant, MediaAttachment
 from maxo.dialogs.api.entities.link_preview import LinkPreviewOptions
 from maxo.dialogs.api.protocols import DialogProtocol
 from maxo.routing.updates import MessageCallback, MessageCreated
-from maxo.types import (
-    CallbackButton,
-    LinkButton,
-    MessageButton,
-    RequestContactButton,
-    RequestGeoLocationButton,
-)
-from maxo.types.open_app_button import OpenAppButton
+from maxo.types import InlineButtons
 
 
 @runtime_checkable
@@ -57,14 +50,7 @@ class LinkPreviewWidget(Widget, Protocol):
         raise NotImplementedError
 
 
-ButtonVariant = (
-    CallbackButton
-    | MessageButton
-    | LinkButton
-    | OpenAppButton
-    | RequestContactButton
-    | RequestGeoLocationButton
-)
+ButtonVariant = InlineButtons
 RawKeyboard = list[list[ButtonVariant]]
 
 

--- a/src/maxo/dialogs/widgets/kbd/__init__.py
+++ b/src/maxo/dialogs/widgets/kbd/__init__.py
@@ -13,6 +13,7 @@ from .calendar_kbd import (
     ManagedCalendar,
 )
 from .checkbox import Checkbox, ManagedCheckbox
+from .confirm_button import ConfirmButton
 from .copy import CopyText
 from .counter import Counter, ManagedCounter
 from .group import Column, Group, Row
@@ -52,6 +53,7 @@ __all__ = (
     "Checkbox",
     "Clipboard",
     "Column",
+    "ConfirmButton",
     "CopyText",
     "Counter",
     "CurrentPage",

--- a/src/maxo/dialogs/widgets/kbd/button.py
+++ b/src/maxo/dialogs/widgets/kbd/button.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, TypeAlias
 
 from maxo.dialogs.api.internal import RawKeyboard, TextWidget
 from maxo.dialogs.api.protocols import DialogManager, DialogProtocol
@@ -14,7 +14,10 @@ from maxo.types import CallbackButton, ClipboardButton, LinkButton, OpenAppButto
 
 from .base import Keyboard
 
-OnClick = Callable[[MessageCallback, "Button", DialogManager], Awaitable[Any]]
+OnClick: TypeAlias = Callable[
+    [MessageCallback, "Button", DialogManager],
+    Awaitable[Any],
+]
 
 
 class Button(Keyboard):

--- a/src/maxo/dialogs/widgets/kbd/button.py
+++ b/src/maxo/dialogs/widgets/kbd/button.py
@@ -14,7 +14,7 @@ from maxo.types import CallbackButton, ClipboardButton, LinkButton, OpenAppButto
 
 from .base import Keyboard
 
-OnClick = Callable[[MessageCallback, "Button", DialogManager], Awaitable]
+OnClick = Callable[[MessageCallback, "Button", DialogManager], Awaitable[Any]]
 
 
 class Button(Keyboard):

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -14,7 +14,7 @@ from maxo.dialogs.widgets.widget_event import (
 from maxo.routing.updates import MessageCallback
 from maxo.types import CallbackButton
 
-OnClick = Callable[[MessageCallback, "ConfirmButton", DialogManager], Awaitable]
+OnClick = Callable[[MessageCallback, "ConfirmButton", DialogManager], Awaitable[Any]]
 
 ACTION_WAIT = "__wait__"
 ACTION_CONFIRM = "__confirm__"

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 
 from maxo.dialogs.api.internal import RawKeyboard, TextWidget
 from maxo.dialogs.api.internal.middleware import PAYLOAD_KEY
@@ -14,7 +14,10 @@ from maxo.dialogs.widgets.widget_event import (
 from maxo.routing.updates import MessageCallback
 from maxo.types import CallbackButton
 
-OnClick = Callable[[MessageCallback, "ConfirmButton", DialogManager], Awaitable[Any]]
+OnClick: TypeAlias = Callable[
+    [MessageCallback, "ConfirmButton", DialogManager],
+    Awaitable[Any],
+]
 
 ACTION_WAIT = "__wait__"
 ACTION_CONFIRM = "__confirm__"

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -31,6 +31,7 @@ class ConfirmButton(Keyboard):
         warning_text: TextWidget | None = None,
         on_confirm: OnClick | WidgetEventProcessor | None = None,
         on_cancel: OnClick | WidgetEventProcessor | None = None,
+        confirm_first: bool = False,
         when: WhenCondition = None,
     ) -> None:
         super().__init__(id=id, when=when)
@@ -40,6 +41,7 @@ class ConfirmButton(Keyboard):
         self.warning_text = warning_text
         self.on_confirm = ensure_event_processor(on_confirm)
         self.on_cancel = ensure_event_processor(on_cancel)
+        self.confirm_first = confirm_first
 
     async def _process_item_callback(
         self,
@@ -74,18 +76,18 @@ class ConfirmButton(Keyboard):
                         ),
                     ],
                 )
-            keyboard.append(
-                [
-                    CallbackButton(
-                        text=await self.cancel_text.render_text(data, manager),
-                        payload=self._item_payload(ACTION_CANCEL),
-                    ),
-                    CallbackButton(
-                        text=await self.confirm_text.render_text(data, manager),
-                        payload=self._item_payload(ACTION_CONFIRM),
-                    ),
-                ],
+            cancel = CallbackButton(
+                text=await self.cancel_text.render_text(data, manager),
+                payload=self._item_payload(ACTION_CANCEL),
             )
+            confirm = CallbackButton(
+                text=await self.confirm_text.render_text(data, manager),
+                payload=self._item_payload(ACTION_CONFIRM),
+            )
+            if self.confirm_first:
+                keyboard.append([confirm, cancel])
+            else:
+                keyboard.append([cancel, confirm])
             return cast(RawKeyboard, keyboard)
 
         # Любая другая кнопка, из другого окна или cancel/confirm

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -1,9 +1,9 @@
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
-from maxo.dialogs import DialogManager, DialogProtocol
 from maxo.dialogs.api.internal import RawKeyboard, TextWidget
 from maxo.dialogs.api.internal.middleware import PAYLOAD_KEY
+from maxo.dialogs.api.protocols import DialogManager, DialogProtocol
 from maxo.dialogs.utils import remove_intent_id
 from maxo.dialogs.widgets.common import WhenCondition
 from maxo.dialogs.widgets.kbd import Keyboard
@@ -62,7 +62,7 @@ class ConfirmButton(Keyboard):
         payload: str | None = manager.middleware_data.get(PAYLOAD_KEY)
         action = self._get_action(payload)
 
-        # Если кнопка с primary_text
+        # Шаг подтверждения: warning + cancel/confirm
         if action == ACTION_WAIT:
             keyboard = []
             if self.warning_text is not None:
@@ -86,7 +86,7 @@ class ConfirmButton(Keyboard):
                     ),
                 ],
             )
-            return keyboard
+            return cast(RawKeyboard, keyboard)
 
         # Любая другая кнопка, из другого окна или cancel/confirm
         return [

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -32,6 +32,7 @@ class ConfirmButton(Keyboard):
         on_confirm: OnClick | WidgetEventProcessor | None = None,
         on_cancel: OnClick | WidgetEventProcessor | None = None,
         confirm_first: bool = False,
+        oneline: bool = True,
         when: WhenCondition = None,
     ) -> None:
         super().__init__(id=id, when=when)
@@ -42,6 +43,7 @@ class ConfirmButton(Keyboard):
         self.on_confirm = ensure_event_processor(on_confirm)
         self.on_cancel = ensure_event_processor(on_cancel)
         self.confirm_first = confirm_first
+        self.oneline = oneline
 
     async def _process_item_callback(
         self,
@@ -84,10 +86,19 @@ class ConfirmButton(Keyboard):
                 text=await self.confirm_text.render_text(data, manager),
                 payload=self._item_payload(ACTION_CONFIRM),
             )
-            if self.confirm_first:
-                keyboard.append([confirm, cancel])
+
+            if self.oneline:
+                if self.confirm_first:
+                    keyboard.append([confirm, cancel])
+                else:
+                    keyboard.append([cancel, confirm])
+            elif self.confirm_first:
+                keyboard.append([confirm])
+                keyboard.append([cancel])
             else:
-                keyboard.append([cancel, confirm])
+                keyboard.append([cancel])
+                keyboard.append([confirm])
+
             return cast(RawKeyboard, keyboard)
 
         # Любая другая кнопка, из другого окна или cancel/confirm

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from maxo.dialogs import DialogManager, DialogProtocol
 from maxo.dialogs.api.internal import RawKeyboard, TextWidget
+from maxo.dialogs.api.internal.middleware import PAYLOAD_KEY
 from maxo.dialogs.utils import remove_intent_id
 from maxo.dialogs.widgets.common import WhenCondition
 from maxo.dialogs.widgets.kbd import Keyboard
@@ -15,6 +16,10 @@ from maxo.types import CallbackButton
 
 OnClick = Callable[[MessageCallback, "ConfirmButton", DialogManager], Awaitable]
 
+ACTION_WAIT = "__wait__"
+ACTION_CONFIRM = "__confirm__"
+ACTION_CANCEL = "__cancel__"
+
 
 class ConfirmButton(Keyboard):
     def __init__(
@@ -23,7 +28,7 @@ class ConfirmButton(Keyboard):
         primary_text: TextWidget,
         confirm_text: TextWidget,
         cancel_text: TextWidget,
-        are_you_sure_text: TextWidget | None = None,
+        warning_text: TextWidget | None = None,
         on_confirm: OnClick | WidgetEventProcessor | None = None,
         on_cancel: OnClick | WidgetEventProcessor | None = None,
         when: WhenCondition = None,
@@ -32,7 +37,7 @@ class ConfirmButton(Keyboard):
         self.primary_text = primary_text
         self.confirm_text = confirm_text
         self.cancel_text = cancel_text
-        self.are_you_sure_text = are_you_sure_text
+        self.warning_text = warning_text
         self.on_confirm = ensure_event_processor(on_confirm)
         self.on_cancel = ensure_event_processor(on_cancel)
 
@@ -43,9 +48,9 @@ class ConfirmButton(Keyboard):
         dialog: DialogProtocol,
         manager: DialogManager,
     ) -> bool:
-        if data == "__confirm__":
+        if data == ACTION_CONFIRM:
             await self.on_confirm.process_event(callback, self, manager)
-        elif data == "__cancel__":
+        elif data == ACTION_CANCEL:
             await self.on_cancel.process_event(callback, self, manager)
         return True
 
@@ -54,36 +59,41 @@ class ConfirmButton(Keyboard):
         data: dict[Any, Any],
         manager: DialogManager,
     ) -> RawKeyboard:
-        payload: str | None = manager.middleware_data.get("aiogd_original_payload")
+        payload: str | None = manager.middleware_data.get(PAYLOAD_KEY)
         action = self._get_action(payload)
 
         # Если кнопка с primary_text
-        if action == "__wait__":
-            return [
-                [
-                    CallbackButton(
-                        text=await self.are_you_sure_text.render_text(data, manager),
-                        payload=f"{self.callback_prefix()}__wait__",
-                    ),
-                ],
+        if action == ACTION_WAIT:
+            keyboard = []
+            if self.warning_text is not None:
+                keyboard.append(
+                    [
+                        CallbackButton(
+                            text=await self.warning_text.render_text(data, manager),
+                            payload=self._item_payload(ACTION_WAIT),
+                        ),
+                    ],
+                )
+            keyboard.append(
                 [
                     CallbackButton(
                         text=await self.cancel_text.render_text(data, manager),
-                        payload=f"{self.callback_prefix()}__cancel__",
+                        payload=self._item_payload(ACTION_CANCEL),
                     ),
                     CallbackButton(
                         text=await self.confirm_text.render_text(data, manager),
-                        payload=f"{self.callback_prefix()}__confirm__",
+                        payload=self._item_payload(ACTION_CONFIRM),
                     ),
                 ],
-            ]
+            )
+            return keyboard
 
         # Любая другая кнопка, из другого окна или cancel/confirm
         return [
             [
                 CallbackButton(
                     text=await self.primary_text.render_text(data, manager),
-                    payload=f"{self.callback_prefix()}__wait__",
+                    payload=self._item_payload(ACTION_WAIT),
                 ),
             ],
         ]
@@ -101,5 +111,4 @@ class ConfirmButton(Keyboard):
             return None
 
         # ищем action (__confirm__ итп)
-        parts = payload.split(":", 1)
-        return parts[1] if len(parts) > 1 else None
+        return payload[len(prefix) :]

--- a/src/maxo/dialogs/widgets/kbd/confirm_button.py
+++ b/src/maxo/dialogs/widgets/kbd/confirm_button.py
@@ -1,0 +1,105 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from maxo.dialogs import DialogManager, DialogProtocol
+from maxo.dialogs.api.internal import RawKeyboard, TextWidget
+from maxo.dialogs.utils import remove_intent_id
+from maxo.dialogs.widgets.common import WhenCondition
+from maxo.dialogs.widgets.kbd import Keyboard
+from maxo.dialogs.widgets.widget_event import (
+    WidgetEventProcessor,
+    ensure_event_processor,
+)
+from maxo.routing.updates import MessageCallback
+from maxo.types import CallbackButton
+
+OnClick = Callable[[MessageCallback, "ConfirmButton", DialogManager], Awaitable]
+
+
+class ConfirmButton(Keyboard):
+    def __init__(
+        self,
+        id: str,
+        primary_text: TextWidget,
+        confirm_text: TextWidget,
+        cancel_text: TextWidget,
+        are_you_sure_text: TextWidget | None = None,
+        on_confirm: OnClick | WidgetEventProcessor | None = None,
+        on_cancel: OnClick | WidgetEventProcessor | None = None,
+        when: WhenCondition = None,
+    ) -> None:
+        super().__init__(id=id, when=when)
+        self.primary_text = primary_text
+        self.confirm_text = confirm_text
+        self.cancel_text = cancel_text
+        self.are_you_sure_text = are_you_sure_text
+        self.on_confirm = ensure_event_processor(on_confirm)
+        self.on_cancel = ensure_event_processor(on_cancel)
+
+    async def _process_item_callback(
+        self,
+        callback: MessageCallback,
+        data: str,
+        dialog: DialogProtocol,
+        manager: DialogManager,
+    ) -> bool:
+        if data == "__confirm__":
+            await self.on_confirm.process_event(callback, self, manager)
+        elif data == "__cancel__":
+            await self.on_cancel.process_event(callback, self, manager)
+        return True
+
+    async def _render_keyboard(
+        self,
+        data: dict[Any, Any],
+        manager: DialogManager,
+    ) -> RawKeyboard:
+        payload: str | None = manager.middleware_data.get("aiogd_original_payload")
+        action = self._get_action(payload)
+
+        # Если кнопка с primary_text
+        if action == "__wait__":
+            return [
+                [
+                    CallbackButton(
+                        text=await self.are_you_sure_text.render_text(data, manager),
+                        payload=f"{self.callback_prefix()}__wait__",
+                    ),
+                ],
+                [
+                    CallbackButton(
+                        text=await self.cancel_text.render_text(data, manager),
+                        payload=f"{self.callback_prefix()}__cancel__",
+                    ),
+                    CallbackButton(
+                        text=await self.confirm_text.render_text(data, manager),
+                        payload=f"{self.callback_prefix()}__confirm__",
+                    ),
+                ],
+            ]
+
+        # Любая другая кнопка, из другого окна или cancel/confirm
+        return [
+            [
+                CallbackButton(
+                    text=await self.primary_text.render_text(data, manager),
+                    payload=f"{self.callback_prefix()}__wait__",
+                ),
+            ],
+        ]
+
+    def _get_action(self, payload: str | None) -> str | None:
+        if payload is None:
+            return None
+
+        # убрать intent, потому что в _render_keyboard попадает что угодно
+        _, payload = remove_intent_id(payload)
+
+        # проверка что кнопка относится к этому виджету
+        prefix = self.callback_prefix()
+        if not prefix or not payload.startswith(prefix):
+            return None
+
+        # ищем action (__confirm__ итп)
+        parts = payload.split(":", 1)
+        return parts[1] if len(parts) > 1 else None

--- a/tests/maxo_dialog/test_confirm_button.py
+++ b/tests/maxo_dialog/test_confirm_button.py
@@ -230,7 +230,7 @@ async def test_click() -> None:
     _assert_keyboard(dialog_message, ("Заказать суши",), ("К пиццам",))
 
 
-async def test_confirm_flag() -> None:
+async def test_render_flags() -> None:
     manager_mock = MagicMock()
     manager_mock.middleware_data = {PAYLOAD_KEY: "id:__wait__"}
 
@@ -239,11 +239,39 @@ async def test_confirm_flag() -> None:
         primary_text=Const("Primary"),
         confirm_text=Const("Confirm"),
         cancel_text=Const("Cancel"),
-        confirm_first=True,
+        confirm_first=False,
+        oneline=True,
     )
-
     keyboard = await button.render_keyboard({}, manager_mock)
+    assert len(keyboard) == 1
+    assert len(keyboard[0]) == 2
+    assert keyboard[0][0].text == "Cancel"
+    assert keyboard[0][1].text == "Confirm"
 
+    button = ConfirmButton(
+        id="id",
+        primary_text=Const("Primary"),
+        confirm_text=Const("Confirm"),
+        cancel_text=Const("Cancel"),
+        confirm_first=False,
+        oneline=False,
+    )
+    keyboard = await button.render_keyboard({}, manager_mock)
+    assert len(keyboard) == 2
+    assert len(keyboard[0]) == 1
+    assert len(keyboard[1]) == 1
+    assert keyboard[0][0].text == "Cancel"
+    assert keyboard[1][0].text == "Confirm"
+
+    button = ConfirmButton(
+        id="id",
+        primary_text=Const("Primary"),
+        confirm_text=Const("Confirm"),
+        cancel_text=Const("Cancel"),
+        confirm_first=True,
+        oneline=True,
+    )
+    keyboard = await button.render_keyboard({}, manager_mock)
     assert len(keyboard) == 1
     assert len(keyboard[0]) == 2
     assert keyboard[0][0].text == "Confirm"
@@ -254,11 +282,12 @@ async def test_confirm_flag() -> None:
         primary_text=Const("Primary"),
         confirm_text=Const("Confirm"),
         cancel_text=Const("Cancel"),
-        confirm_first=False,
+        confirm_first=True,
+        oneline=False,
     )
-
     keyboard = await button.render_keyboard({}, manager_mock)
-    assert len(keyboard) == 1
-    assert len(keyboard[0]) == 2
-    assert keyboard[0][0].text == "Cancel"
-    assert keyboard[0][1].text == "Confirm"
+    assert len(keyboard) == 2
+    assert len(keyboard[0]) == 1
+    assert len(keyboard[1]) == 1
+    assert keyboard[0][0].text == "Confirm"
+    assert keyboard[1][0].text == "Cancel"

--- a/tests/maxo_dialog/test_confirm_button.py
+++ b/tests/maxo_dialog/test_confirm_button.py
@@ -239,7 +239,7 @@ async def test_confirm_flag() -> None:
         primary_text=Const("Primary"),
         confirm_text=Const("Confirm"),
         cancel_text=Const("Cancel"),
-        confirm_first=True
+        confirm_first=True,
     )
 
     keyboard = await button.render_keyboard({}, manager_mock)
@@ -254,7 +254,7 @@ async def test_confirm_flag() -> None:
         primary_text=Const("Primary"),
         confirm_text=Const("Confirm"),
         cancel_text=Const("Cancel"),
-        confirm_first=False
+        confirm_first=False,
     )
 
     keyboard = await button.render_keyboard({}, manager_mock)

--- a/tests/maxo_dialog/test_confirm_button.py
+++ b/tests/maxo_dialog/test_confirm_button.py
@@ -9,6 +9,7 @@ from maxo.dialogs import (
     Window,
     setup_dialogs,
 )
+from maxo.dialogs.api.internal import PAYLOAD_KEY
 from maxo.dialogs.test_tools import BotClient, MockMessageManager
 from maxo.dialogs.test_tools.keyboard import InlineButtonTextLocator
 from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
@@ -227,3 +228,37 @@ async def test_click() -> None:
     await client.click(dialog_message, InlineButtonTextLocator("К сушам"))
     dialog_message = message_manager.one_message()
     _assert_keyboard(dialog_message, ("Заказать суши",), ("К пиццам",))
+
+
+async def test_confirm_flag() -> None:
+    manager_mock = MagicMock()
+    manager_mock.middleware_data = {PAYLOAD_KEY: "id:__wait__"}
+
+    button = ConfirmButton(
+        id="id",
+        primary_text=Const("Primary"),
+        confirm_text=Const("Confirm"),
+        cancel_text=Const("Cancel"),
+        confirm_first=True
+    )
+
+    keyboard = await button.render_keyboard({}, manager_mock)
+
+    assert len(keyboard) == 1
+    assert len(keyboard[0]) == 2
+    assert keyboard[0][0].text == "Confirm"
+    assert keyboard[0][1].text == "Cancel"
+
+    button = ConfirmButton(
+        id="id",
+        primary_text=Const("Primary"),
+        confirm_text=Const("Confirm"),
+        cancel_text=Const("Cancel"),
+        confirm_first=False
+    )
+
+    keyboard = await button.render_keyboard({}, manager_mock)
+    assert len(keyboard) == 1
+    assert len(keyboard[0]) == 2
+    assert keyboard[0][0].text == "Cancel"
+    assert keyboard[0][1].text == "Confirm"

--- a/tests/maxo_dialog/test_confirm_button.py
+++ b/tests/maxo_dialog/test_confirm_button.py
@@ -12,7 +12,7 @@ from maxo.dialogs import (
 from maxo.dialogs.test_tools import BotClient, MockMessageManager
 from maxo.dialogs.test_tools.keyboard import InlineButtonTextLocator
 from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
-from maxo.dialogs.widgets.kbd import ConfirmButton
+from maxo.dialogs.widgets.kbd import ConfirmButton, SwitchTo
 from maxo.dialogs.widgets.text import Const
 from maxo.fsm import State, StatesGroup
 from maxo.fsm.key_builder import DefaultKeyBuilder
@@ -20,10 +20,12 @@ from maxo.fsm.storages.memory import SimpleEventIsolation
 from maxo.routing.filters import CommandStart
 from maxo.routing.signals import AfterStartup, BeforeStartup
 from maxo.routing.updates import MessageCallback, MessageCreated
+from maxo.types import Message
 
 
-class MainSG(StatesGroup):
-    main = State()
+class OrderSG(StatesGroup):
+    pizza = State()
+    sushi = State()
 
 
 async def on_pizza(
@@ -52,7 +54,7 @@ async def on_sushi(
 
 confirm_dialog = Dialog(
     Window(
-        Const("Нажми на любой заказ"),
+        Const("Пицца"),
         ConfirmButton(
             primary_text=Const("Заказать пиццу"),
             confirm_text=Const("Точно"),
@@ -62,6 +64,11 @@ confirm_dialog = Dialog(
             on_cancel=on_pizza_cancel,
             id="pizza",
         ),
+        SwitchTo(Const("К сушам"), state=OrderSG.sushi, id="to_sushi"),
+        state=OrderSG.pizza,
+    ),
+    Window(
+        Const("Суши"),
         ConfirmButton(
             primary_text=Const("Заказать суши"),
             confirm_text=Const("Точно суши"),
@@ -71,13 +78,25 @@ confirm_dialog = Dialog(
             on_cancel=None,
             id="sushi",
         ),
-        state=MainSG.main,
+        SwitchTo(Const("К пиццам"), state=OrderSG.pizza, id="to_pizza"),
+        state=OrderSG.sushi,
     ),
 )
 
 
 async def start(message: MessageCreated, dialog_manager: DialogManager) -> None:
-    await dialog_manager.start(MainSG.main, mode=StartMode.RESET_STACK)
+    await dialog_manager.start(OrderSG.pizza, mode=StartMode.RESET_STACK)
+
+
+def _assert_keyboard(message: Message, *buttons: tuple[str, ...]) -> None:
+    keyboard = message.body.keyboard
+    assert keyboard
+    assert len(keyboard.buttons) == len(buttons)
+
+    for i, row in enumerate(buttons):
+        assert len(keyboard.buttons[i]) == len(row)
+        for button, text in zip(keyboard.buttons[i], row, strict=True):
+            assert button.text == text
 
 
 async def test_click() -> None:
@@ -109,63 +128,76 @@ async def test_click() -> None:
 
     await client.send("/start")
     dialog_message = message_manager.one_message()
-    assert dialog_message.body.text == "Нажми на любой заказ"
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+    assert dialog_message.body.text == "Пицца"
+    _assert_keyboard(dialog_message, ("Заказать пиццу",), ("К сушам",))
 
+    # Проверка отмены
     message_manager.reset_history()
     await client.click(dialog_message, InlineButtonTextLocator("Заказать пиццу"))
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 3
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
-    assert len(dialog_message.body.reply_markup.buttons[2]) == 1
+    _assert_keyboard(
+        dialog_message,
+        ("Подтверди заказ пиццы",),
+        ("Передумал", "Точно"),
+        ("К сушам",),
+    )
 
     message_manager.reset_history()
     cancel_id = await client.click(dialog_message, InlineButtonTextLocator("Передумал"))
     on_pizza_cancel_mock.assert_called_once_with(cancel_id)
+    on_pizza_mock.assert_not_called()
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+    _assert_keyboard(dialog_message, ("Заказать пиццу",), ("К сушам",))
 
+    # Проверка подтверждения
     message_manager.reset_history()
     await client.click(dialog_message, InlineButtonTextLocator("Заказать пиццу"))
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 3
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
-    assert len(dialog_message.body.reply_markup.buttons[2]) == 1
+    _assert_keyboard(
+        dialog_message,
+        ("Подтверди заказ пиццы",),
+        ("Передумал", "Точно"),
+        ("К сушам",),
+    )
 
     message_manager.reset_history()
     confirm_id = await client.click(dialog_message, InlineButtonTextLocator("Точно"))
     on_pizza_mock.assert_called_once_with(confirm_id)
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+    _assert_keyboard(dialog_message, ("Заказать пиццу",), ("К сушам",))
 
+    # Переходим к сушам
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("К сушам"))
+    dialog_message = message_manager.one_message()
+    assert dialog_message.body.text == "Суши"
+    _assert_keyboard(dialog_message, ("Заказать суши",), ("К пиццам",))
+
+    # Проверка отмены
     message_manager.reset_history()
     await client.click(dialog_message, InlineButtonTextLocator("Заказать суши"))
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
+    _assert_keyboard(
+        dialog_message,
+        ("Передумал, не суши", "Точно суши"),
+        ("К пиццам",),
+    )
 
     message_manager.reset_history()
     await client.click(dialog_message, InlineButtonTextLocator("Передумал, не суши"))
+    on_sushi_mock.assert_not_called()
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+    _assert_keyboard(dialog_message, ("Заказать суши",), ("К пиццам",))
 
+    # Проверка подтверждения
     message_manager.reset_history()
     await client.click(dialog_message, InlineButtonTextLocator("Заказать суши"))
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
+    _assert_keyboard(
+        dialog_message,
+        ("Передумал, не суши", "Точно суши"),
+        ("К пиццам",),
+    )
 
     message_manager.reset_history()
     confirm_id = await client.click(
@@ -174,6 +206,24 @@ async def test_click() -> None:
     )
     on_sushi_mock.assert_called_once_with(confirm_id)
     dialog_message = message_manager.one_message()
-    assert len(dialog_message.body.reply_markup.buttons) == 2
-    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
-    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+    _assert_keyboard(dialog_message, ("Заказать суши",), ("К пиццам",))
+
+    # Проверка сброса между свитчами
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("Заказать суши"))
+    dialog_message = message_manager.one_message()
+    _assert_keyboard(
+        dialog_message,
+        ("Передумал, не суши", "Точно суши"),
+        ("К пиццам",),
+    )
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("К пиццам"))
+    dialog_message = message_manager.one_message()
+    _assert_keyboard(dialog_message, ("Заказать пиццу",), ("К сушам",))
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("К сушам"))
+    dialog_message = message_manager.one_message()
+    _assert_keyboard(dialog_message, ("Заказать суши",), ("К пиццам",))

--- a/tests/maxo_dialog/test_confirm_button.py
+++ b/tests/maxo_dialog/test_confirm_button.py
@@ -1,0 +1,179 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+from maxo import Dispatcher
+from maxo.dialogs import (
+    Dialog,
+    DialogManager,
+    StartMode,
+    Window,
+    setup_dialogs,
+)
+from maxo.dialogs.test_tools import BotClient, MockMessageManager
+from maxo.dialogs.test_tools.keyboard import InlineButtonTextLocator
+from maxo.dialogs.test_tools.memory_storage import JsonMemoryStorage
+from maxo.dialogs.widgets.kbd import ConfirmButton
+from maxo.dialogs.widgets.text import Const
+from maxo.fsm import State, StatesGroup
+from maxo.fsm.key_builder import DefaultKeyBuilder
+from maxo.fsm.storages.memory import SimpleEventIsolation
+from maxo.routing.filters import CommandStart
+from maxo.routing.signals import AfterStartup, BeforeStartup
+from maxo.routing.updates import MessageCallback, MessageCreated
+
+
+class MainSG(StatesGroup):
+    main = State()
+
+
+async def on_pizza(
+    callback: MessageCallback,
+    _: Any,
+    dialog_manager: DialogManager,
+) -> None:
+    dialog_manager.middleware_data["on_pizza"](callback.id)
+
+
+async def on_pizza_cancel(
+    callback: MessageCallback,
+    _: Any,
+    dialog_manager: DialogManager,
+) -> None:
+    dialog_manager.middleware_data["on_pizza_cancel"](callback.id)
+
+
+async def on_sushi(
+    callback: MessageCallback,
+    _: Any,
+    dialog_manager: DialogManager,
+) -> None:
+    dialog_manager.middleware_data["on_sushi"](callback.id)
+
+
+confirm_dialog = Dialog(
+    Window(
+        Const("Нажми на любой заказ"),
+        ConfirmButton(
+            primary_text=Const("Заказать пиццу"),
+            confirm_text=Const("Точно"),
+            cancel_text=Const("Передумал"),
+            warning_text=Const("Подтверди заказ пиццы"),
+            on_confirm=on_pizza,
+            on_cancel=on_pizza_cancel,
+            id="pizza",
+        ),
+        ConfirmButton(
+            primary_text=Const("Заказать суши"),
+            confirm_text=Const("Точно суши"),
+            cancel_text=Const("Передумал, не суши"),
+            warning_text=None,
+            on_confirm=on_sushi,
+            on_cancel=None,
+            id="sushi",
+        ),
+        state=MainSG.main,
+    ),
+)
+
+
+async def start(message: MessageCreated, dialog_manager: DialogManager) -> None:
+    await dialog_manager.start(MainSG.main, mode=StartMode.RESET_STACK)
+
+
+async def test_click() -> None:
+    on_pizza_mock = MagicMock()
+    on_pizza_cancel_mock = MagicMock()
+    on_sushi_mock = MagicMock()
+
+    key_builder = DefaultKeyBuilder(with_destiny=True)
+    event_isolation = SimpleEventIsolation(key_builder=key_builder)
+    dp = Dispatcher(
+        storage=JsonMemoryStorage(),
+        events_isolation=event_isolation,
+        key_builder=key_builder,
+        workflow_data={
+            "on_pizza": on_pizza_mock,
+            "on_pizza_cancel": on_pizza_cancel_mock,
+            "on_sushi": on_sushi_mock,
+        },
+    )
+    dp.include(confirm_dialog)
+    dp.message_created.handler(start, CommandStart())
+
+    client = BotClient(dp)
+    message_manager = MockMessageManager()
+    setup_dialogs(dp, message_manager=message_manager, events_isolation=event_isolation)
+
+    await dp.feed_signal(BeforeStartup(), client.bot)
+    await dp.feed_signal(AfterStartup(), client.bot)
+
+    await client.send("/start")
+    dialog_message = message_manager.one_message()
+    assert dialog_message.body.text == "Нажми на любой заказ"
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("Заказать пиццу"))
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 3
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
+    assert len(dialog_message.body.reply_markup.buttons[2]) == 1
+
+    message_manager.reset_history()
+    cancel_id = await client.click(dialog_message, InlineButtonTextLocator("Передумал"))
+    on_pizza_cancel_mock.assert_called_once_with(cancel_id)
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("Заказать пиццу"))
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 3
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
+    assert len(dialog_message.body.reply_markup.buttons[2]) == 1
+
+    message_manager.reset_history()
+    confirm_id = await client.click(dialog_message, InlineButtonTextLocator("Точно"))
+    on_pizza_mock.assert_called_once_with(confirm_id)
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("Заказать суши"))
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("Передумал, не суши"))
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 1
+
+    message_manager.reset_history()
+    await client.click(dialog_message, InlineButtonTextLocator("Заказать суши"))
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 2
+
+    message_manager.reset_history()
+    confirm_id = await client.click(
+        dialog_message,
+        InlineButtonTextLocator("Точно суши"),
+    )
+    on_sushi_mock.assert_called_once_with(confirm_id)
+    dialog_message = message_manager.one_message()
+    assert len(dialog_message.body.reply_markup.buttons) == 2
+    assert len(dialog_message.body.reply_markup.buttons[0]) == 1
+    assert len(dialog_message.body.reply_markup.buttons[1]) == 1


### PR DESCRIPTION
# Описание

Кнопка с двойным подтверждением, чтобы не создавать под подтверждение отдельные окна. Не хранит состояние в диалог дате, чтобы она сбрасывалась до primary между switch'ами

## Тип изменения

- [x] Документация (опечатки, примеры кода или любые другие обновления документации)
- [x] Новый функционал (некритическое изменение, добавляющее функциональность)
- [x] Это изменение требует обновления документации

# Как это было протестировано?

Нужно протестить

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я внес соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично написано нейросетями, но прошёл полную проверку со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Обновление

* **Новые возможности**
  * Добавлен виджет **ConfirmButton** для диалогов подтверждения: последовательность *подтверждение → ожидание (опционально с предупреждением) → повторное нажатие*; поддерживаются порядок кнопок и формат в одну/две строки.
* **Примеры**
  * Добавлен пример диалога с подтверждением для двух сценариев (с отменой и без).
* **Экспорт**
  * **ConfirmButton** доступен через публичный экспорт виджетов.
* **Документация**
  * Добавлен раздел **ConfirmButton** с описанием параметров и сценариев.
* **Тесты**
  * Добавлены интеграционные тесты и проверки отрисовки при разных настройках.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->