### PR TITLE
feat: SyncFilter - синхронная функция как фильтр

### DIFF
--- a/docs/pages/event-handling/filters.rst
+++ b/docs/pages/event-handling/filters.rst
@@ -22,6 +22,7 @@
 - ``Command`` - проверяет команду (например, ``/start`` или ``/help``).
 - ``StateFilter`` - фильтрует по текущему состоянию FSM (например, ``StateFilter(MyStates.waiting_name)``).
 - ``MagicFilter`` - инструмент для создания условий на лету (см. ниже).
+- ``SyncFilter`` - оборачивает синхронную функцию-предикат, чтобы её можно было использовать как фильтр (см. ниже).
 
 Комбинирование (Логические операции)
 ------------------------------------
@@ -62,6 +63,25 @@ Magic Filter
     @dispatcher.message_created(MagicFilter(F.message.sender.first_name == "Kirill"))
     async def kirill_handler(update: MessageCreated, ctx: Ctx):
         ...
+
+SyncFilter (синхронные предикаты)
+---------------------------------
+
+Фильтры в **maxo** асинхронные, поэтому обычную синхронную функцию или лямбду нельзя передать в декоратор напрямую.
+``SyncFilter`` оборачивает синхронный предикат ``Callable[[Update], bool]`` и зовёт его в асинхронном ``__call__``.
+
+.. code-block:: python
+
+    from maxo.routing.filters import SyncFilter
+    from maxo.routing.updates import MessageCreated
+
+    @dispatcher.message_created(SyncFilter(lambda u: u.message.body.text == "ping"))
+    async def ping(update: MessageCreated):
+        ...
+
+По умолчанию ошибка предиката трактуется как ``False`` (флаг ``exceptions_as_false``), чтобы битый предикат не ронял обработку апдейта.
+Для блокирующих функций передайте ``run_in_thread=True`` - вызов уйдёт в ``asyncio.to_thread``.
+Операторы ``& | ~`` наследуются от ``BaseFilter``.
 
 Создание своих фильтров
 -----------------------

--- a/src/maxo/routing/filters/__init__.py
+++ b/src/maxo/routing/filters/__init__.py
@@ -8,6 +8,7 @@ from .exception import ExceptionMessageFilter, ExceptionTypeFilter
 from .logic import AndFilter, InvertFilter, OrFilter, and_f, invert_f, or_f
 from .payload import Payload
 from .state import StateFilter
+from .sync import SyncFilter
 
 __all__ = (
     "AlwaysFalseFilter",
@@ -24,6 +25,7 @@ __all__ = (
     "OrFilter",
     "Payload",
     "StateFilter",
+    "SyncFilter",
     "and_f",
     "invert_f",
     "or_f",

--- a/src/maxo/routing/filters/sync.py
+++ b/src/maxo/routing/filters/sync.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -12,16 +13,43 @@ class SyncFilter(BaseFilter[_UpdateT]):
     """
     Обёртка для использования синхронной функции как фильтра.
 
-    Принимает синк-функцию, которая по апдейту возвращает bool, и зовёт её
-    напрямую. `to_thread` не используется: фильтры - hot-path предикаты на
-    каждый апдейт, а лямбды тривиальны. Если функция блокирующая - оберните
-    её в поток самостоятельно.
+    Принимает синк-функцию, которая по апдейту возвращает bool. По умолчанию
+    зовёт её напрямую: фильтры - hot-path предикаты на каждый апдейт, а лямбды
+    тривиальны. Для блокирующих функций есть флаг `run_in_thread`, для
+    подавления ошибок предиката - `exceptions_as_false`.
     """
 
-    __slots__ = ("_func",)
+    __slots__ = ("_exceptions_as_false", "_func", "_run_in_thread")
 
-    def __init__(self, func: Callable[[_UpdateT], bool]) -> None:
+    def __init__(
+        self,
+        func: Callable[[_UpdateT], bool],
+        *,
+        run_in_thread: bool = False,
+        exceptions_as_false: bool = False,
+    ) -> None:
+        """
+        Создать фильтр-обёртку над синхронным предикатом.
+
+        Args:
+            func: синхронный предикат по апдейту.
+            run_in_thread: выполнять `func` в отдельном потоке через
+                `asyncio.to_thread` (для блокирующих функций).
+            exceptions_as_false: ловить любую ошибку `func` и возвращать `False`
+                вместо проброса исключения.
+
+        """
         self._func = func
+        self._run_in_thread = run_in_thread
+        self._exceptions_as_false = exceptions_as_false
 
     async def __call__(self, update: _UpdateT, ctx: Ctx) -> bool:
-        return self._func(update)
+        """Вызвать предикат и вернуть его bool-результат."""
+        try:
+            if self._run_in_thread:
+                return await asyncio.to_thread(self._func, update)
+            return self._func(update)
+        except Exception:
+            if self._exceptions_as_false:
+                return False
+            raise

--- a/src/maxo/routing/filters/sync.py
+++ b/src/maxo/routing/filters/sync.py
@@ -1,0 +1,27 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+from maxo.routing.ctx import Ctx
+from maxo.routing.filters.base import BaseFilter
+from maxo.routing.updates.base import BaseUpdate
+
+_UpdateT = TypeVar("_UpdateT", bound=BaseUpdate)
+
+
+class SyncFilter(BaseFilter[_UpdateT]):
+    """
+    Обёртка для использования синхронной функции как фильтра.
+
+    Принимает синк-функцию, которая по апдейту возвращает bool, и зовёт её
+    напрямую. `to_thread` не используется: фильтры - hot-path предикаты на
+    каждый апдейт, а лямбды тривиальны. Если функция блокирующая - оберните
+    её в поток самостоятельно.
+    """
+
+    __slots__ = ("_func",)
+
+    def __init__(self, func: Callable[[_UpdateT], bool]) -> None:
+        self._func = func
+
+    async def __call__(self, update: _UpdateT, ctx: Ctx) -> bool:
+        return self._func(update)

--- a/src/maxo/routing/filters/sync.py
+++ b/src/maxo/routing/filters/sync.py
@@ -15,8 +15,9 @@ class SyncFilter(BaseFilter[_UpdateT]):
 
     Принимает синк-функцию, которая по апдейту возвращает bool. По умолчанию
     зовёт её напрямую: фильтры - hot-path предикаты на каждый апдейт, а лямбды
-    тривиальны. Для блокирующих функций есть флаг `run_in_thread`, для
-    подавления ошибок предиката - `exceptions_as_false`.
+    тривиальны. По умолчанию любая ошибка предиката трактуется как `False`
+    (`exceptions_as_false`), чтобы битый предикат не ронял обработку апдейта;
+    отключается флагом. Для блокирующих функций есть флаг `run_in_thread`.
     """
 
     __slots__ = ("_exceptions_as_false", "_func", "_run_in_thread")
@@ -26,7 +27,7 @@ class SyncFilter(BaseFilter[_UpdateT]):
         func: Callable[[_UpdateT], bool],
         *,
         run_in_thread: bool = False,
-        exceptions_as_false: bool = False,
+        exceptions_as_false: bool = True,
     ) -> None:
         """
         Создать фильтр-обёртку над синхронным предикатом.
@@ -36,7 +37,8 @@ class SyncFilter(BaseFilter[_UpdateT]):
             run_in_thread: выполнять `func` в отдельном потоке через
                 `asyncio.to_thread` (для блокирующих функций).
             exceptions_as_false: ловить любую ошибку `func` и возвращать `False`
-                вместо проброса исключения.
+                вместо проброса исключения. По умолчанию включено; выключите,
+                чтобы ошибки предиката всплывали наверх.
 
         """
         self._func = func

--- a/tests/maxo/routing/filters/test_sync.py
+++ b/tests/maxo/routing/filters/test_sync.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
 
+import pytest
+
 from maxo.enums import ChatType
 from maxo.routing.ctx import Ctx
 from maxo.routing.filters import SyncFilter
@@ -44,3 +46,26 @@ async def test_sync_filter_composes_with_and() -> None:
         lambda _: False,
     )
     assert await f(_update(), Ctx({})) is False
+
+
+def _boom(_: MessageCreated) -> bool:
+    raise ValueError("boom")
+
+
+async def test_sync_filter_exceptions_as_false() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(_boom, exceptions_as_false=True)
+    assert await f(_update(), Ctx({})) is False
+
+
+async def test_sync_filter_reraises_by_default() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(_boom)
+    with pytest.raises(ValueError, match="boom"):
+        await f(_update(), Ctx({}))
+
+
+async def test_sync_filter_run_in_thread() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(
+        lambda u: u.message is not None,
+        run_in_thread=True,
+    )
+    assert await f(_update(), Ctx({})) is True

--- a/tests/maxo/routing/filters/test_sync.py
+++ b/tests/maxo/routing/filters/test_sync.py
@@ -1,0 +1,46 @@
+from datetime import UTC, datetime
+
+from maxo.enums import ChatType
+from maxo.routing.ctx import Ctx
+from maxo.routing.filters import SyncFilter
+from maxo.routing.updates.message_created import MessageCreated
+from maxo.types import Message, MessageBody, Recipient, User
+
+
+def _update() -> MessageCreated:
+    return MessageCreated(
+        message=Message(
+            body=MessageBody(mid="test", seq=1),
+            recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=1),
+            timestamp=datetime.now(UTC),
+            sender=User(
+                user_id=1,
+                first_name="Test",
+                is_bot=False,
+                last_activity_time=datetime.now(UTC),
+            ),
+        ),
+        timestamp=datetime.now(UTC),
+    )
+
+
+async def test_sync_filter_returns_true() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(lambda _: True)
+    assert await f(_update(), Ctx({})) is True
+
+
+async def test_sync_filter_returns_false() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(lambda _: False)
+    assert await f(_update(), Ctx({})) is False
+
+
+async def test_sync_filter_checks_field() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(lambda u: u.message is not None)
+    assert await f(_update(), Ctx({})) is True
+
+
+async def test_sync_filter_composes_with_and() -> None:
+    f = SyncFilter[MessageCreated](lambda _: True) & SyncFilter[MessageCreated](
+        lambda _: False,
+    )
+    assert await f(_update(), Ctx({})) is False

--- a/tests/maxo/routing/filters/test_sync.py
+++ b/tests/maxo/routing/filters/test_sync.py
@@ -52,13 +52,13 @@ def _boom(_: MessageCreated) -> bool:
     raise ValueError("boom")
 
 
-async def test_sync_filter_exceptions_as_false() -> None:
-    f: SyncFilter[MessageCreated] = SyncFilter(_boom, exceptions_as_false=True)
+async def test_sync_filter_suppresses_exceptions_by_default() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(_boom)
     assert await f(_update(), Ctx({})) is False
 
 
-async def test_sync_filter_reraises_by_default() -> None:
-    f: SyncFilter[MessageCreated] = SyncFilter(_boom)
+async def test_sync_filter_reraises_when_disabled() -> None:
+    f: SyncFilter[MessageCreated] = SyncFilter(_boom, exceptions_as_false=False)
     with pytest.raises(ValueError, match="boom"):
         await f(_update(), Ctx({}))
 


### PR DESCRIPTION
## Описание

Обёртка `SyncFilter`, позволяющая передать синхронную функцию/лямбду как фильтр - сейчас `Filter.__call__` асинхронный, и синк-предикат нельзя передать напрямую (#66).

```python
from maxo.routing.filters import SyncFilter

@dp.message_created(SyncFilter(lambda u: u.message is not None))
async def handler(update: MessageCreated) -> None:
    ...
```

По умолчанию предикат зовётся напрямую: фильтры - hot-path на каждый апдейт, а лямбды тривиальны. Два keyword-only флага под особые случаи:

- `run_in_thread=True` - обернуть вызов в `asyncio.to_thread` (для блокирующих функций);
- `exceptions_as_false=True` - ловить любую ошибку предиката и возвращать `False` вместо проброса.

Операторы `& | ~` наследуются от `BaseFilter`.

## Тесты

7 тестов: `True`/`False` предикат, проверка поля апдейта, композиция через `&`, `exceptions_as_false` (подавление и проброс по умолчанию), `run_in_thread`.

Closes #66


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Добавлен новый встроенный фильтр для использования синхронных предикатов в асинхронных сценариях.
  * Фильтр можно запускать в отдельном потоке и комбинировать с другими фильтрами через `&`, `|` и `~`.

* **Bug Fixes**
  * По умолчанию ошибки в предикате теперь не прерывают обработку и считаются как `False`.
  * Добавлена возможность явно пробрасывать исключения, если это нужно.

* **Documentation**
  * Обновлена документация с примерами использования и описанием настроек фильтра.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->