### PR TITLE
feat: CallbackAnswerMiddleware - авто-ответ на колбэк

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -171,6 +171,7 @@ Contributors
    :hidden:
 
    pages/utils/link
+   pages/utils/callback_answer
 
 .. toctree::
    :maxdepth: 1

--- a/docs/pages/utils/callback_answer.rst
+++ b/docs/pages/utils/callback_answer.rst
@@ -1,0 +1,50 @@
+Авто-ответ на колбэк
+====================
+
+``CallbackAnswerMiddleware`` автоматически отвечает на ``MessageCallback`` (колбэк от нажатия инлайн-кнопки).
+Порт ``CallbackAnswerMiddleware`` из ``aiogram``.
+
+Подключение
+-----------
+
+Middleware - внутренний (inner), вешается на обсёрвер ``message_callback``:
+
+.. code-block:: python
+
+    from maxo import Dispatcher
+    from maxo.utils.callback_answer import CallbackAnswerMiddleware
+
+    dp = Dispatcher()
+    dp.message_callback.middleware(CallbackAnswerMiddleware())
+
+По умолчанию middleware отвечает пустым ответом **после** хендлера. Ответ
+отправляется даже если хендлер бросил исключение.
+
+Управление из хендлера
+----------------------
+
+Middleware кладёт в ctx мутабельный ``CallbackAnswer`` под ключом
+``callback_answer``. Хендлер, объявивший параметр ``callback_answer``, может
+поменять поведение до того, как middleware ответит:
+
+.. code-block:: python
+
+    from maxo.routing.updates import MessageCallback
+    from maxo.utils.callback_answer import CallbackAnswer
+
+
+    @dp.message_callback()
+    async def handler(
+        update: MessageCallback,
+        callback_answer: CallbackAnswer,
+    ) -> None:
+        callback_answer.notification = "Готово!"  # текст всплывашки
+        # callback_answer.disable()               # не отвечать вовсе
+
+После отправки ответа ``CallbackAnswer`` становится неизменяемым: запись в любое
+поле поднимает ``CallbackAnswerException``.
+
+.. automodule:: maxo.utils.callback_answer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/maxo/utils/callback_answer.py
+++ b/src/maxo/utils/callback_answer.py
@@ -1,30 +1,113 @@
+"""
+https://github.com/aiogram/aiogram/blob/dev-3.x/aiogram/utils/callback_answer.py.
+
+Original code licensed under MIT by aiogram contributors
+
+The MIT License (MIT)
+
+Copyright (c) 2017 - present Alex Root Junior
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
 from typing import Any
 
+from maxo.errors import MaxoError
 from maxo.routing.ctx import Ctx
 from maxo.routing.interfaces.middleware import BaseMiddleware, NextMiddleware
 from maxo.routing.updates.message_callback import MessageCallback
-from maxo.types import MaxoType
 
 CALLBACK_ANSWER_KEY = "callback_answer"
 
 
-class CallbackAnswer(MaxoType):
+class CallbackAnswerException(MaxoError):
+    """Попытка изменить `CallbackAnswer` после того, как ответ уже отправлен."""
+
+    def __str__(self) -> str:
+        return "Нельзя изменить CallbackAnswer после отправки ответа на колбэк"
+
+
+class CallbackAnswer:
     """
     Управление авто-ответом на колбэк из хендлера.
 
-    Middleware кладёт объект в ctx под ключом `CALLBACK_ANSWER_KEY`. Хендлер,
-    объявивший параметр `callback_answer: CallbackAnswer`, может его мутировать
-    до того, как middleware ответит.
+    Middleware кладёт объект в ctx под ключом `CALLBACK_ANSWER_KEY`.
+    Хендлер, объявивший параметр `callback_answer: CallbackAnswer`,
+    может его мутировать до того, как middleware ответит
     """
 
-    disabled: bool = False
-    """Не отвечать на этот колбэк."""
-    before: bool = False
-    """Ответить до хендлера, а не после."""
-    notification: str | None = None
-    """Текст одноразового уведомления (иначе пустой ответ)."""
-    answered: bool = False
-    """Внутреннее: ответ уже отправлен."""
+    __slots__ = ("_answered", "_before", "_disabled", "_notification")
+
+    def __init__(
+        self,
+        *,
+        disabled: bool = False,
+        before: bool = False,
+        notification: str | None = None,
+        answered: bool = False,
+    ) -> None:
+        self._disabled = disabled
+        self._before = before
+        self._notification = notification
+        self._answered = answered
+
+    @property
+    def answered(self) -> bool:
+        """Внутреннее: ответ уже отправлен (только для чтения)."""
+        return self._answered
+
+    @property
+    def disabled(self) -> bool:
+        """Не отвечать на этот колбэк."""
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, value: bool) -> None:
+        self._raise_if_answered()
+        self._disabled = value
+
+    @property
+    def before(self) -> bool:
+        """Ответить до хендлера, а не после."""
+        return self._before
+
+    @before.setter
+    def before(self, value: bool) -> None:
+        self._raise_if_answered()
+        self._before = value
+
+    @property
+    def notification(self) -> str | None:
+        """Текст одноразового уведомления (иначе пустой ответ)."""
+        return self._notification
+
+    @notification.setter
+    def notification(self, value: str | None) -> None:
+        self._raise_if_answered()
+        self._notification = value
+
+    def disable(self) -> None:
+        """Отключить авто-ответ на этот колбэк."""
+        self.disabled = True
+
+    def _raise_if_answered(self) -> None:
+        if self._answered:
+            raise CallbackAnswerException
 
 
 class CallbackAnswerMiddleware(BaseMiddleware[MessageCallback]):
@@ -64,16 +147,18 @@ class CallbackAnswerMiddleware(BaseMiddleware[MessageCallback]):
         if answer.before and not answer.disabled:
             await self._answer(update, answer)
 
-        result = await next(ctx)
-
-        if not answer.disabled and not answer.answered:
-            await self._answer(update, answer)
-
-        return result
+        try:
+            return await next(ctx)
+        finally:
+            if not answer.disabled and not answer.answered:
+                await self._answer(update, answer)
 
     async def _answer(self, update: MessageCallback, answer: CallbackAnswer) -> None:
         if answer.notification is not None:
             await update.answer(notification=answer.notification)
         else:
             await update.answer()
-        answer.answered = True
+        # `answered` намеренно read-only для хендлеров (публичного сеттера нет),
+        # а middleware и CallbackAnswer - тесно связаны в одном модуле,
+        # поэтому внутренний флаг ставим напрямую
+        answer._answered = True  # noqa: SLF001

--- a/src/maxo/utils/callback_answer.py
+++ b/src/maxo/utils/callback_answer.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+from typing import Any
+
+from maxo.routing.ctx import Ctx
+from maxo.routing.interfaces.middleware import BaseMiddleware, NextMiddleware
+from maxo.routing.updates.message_callback import MessageCallback
+
+CALLBACK_ANSWER_KEY = "callback_answer"
+
+
+@dataclass(slots=True)
+class CallbackAnswer:
+    """
+    Управление авто-ответом на колбэк из хендлера.
+
+    Middleware кладёт объект в ctx под ключом `CALLBACK_ANSWER_KEY`. Хендлер,
+    объявивший параметр `callback_answer: CallbackAnswer`, может его мутировать
+    до того, как middleware ответит.
+    """
+
+    disabled: bool = False
+    """Не отвечать на этот колбэк."""
+    before: bool = False
+    """Ответить до хендлера, а не после."""
+    notification: str | None = None
+    """Текст одноразового уведомления (иначе пустой ответ)."""
+    answered: bool = False
+    """Внутреннее: ответ уже отправлен."""
+
+
+class CallbackAnswerMiddleware(BaseMiddleware[MessageCallback]):
+    """
+    Inner-middleware: автоматически отвечает на колбэк.
+
+    Дефолты задаются в конструкторе. Хендлер может переопределить поведение,
+    мутируя `CallbackAnswer` из ctx. Аналог aiogram CallbackAnswerMiddleware,
+    но без механизма flags - конфиг через мутабельный объект в ctx.
+    """
+
+    __slots__ = ("_before", "_disabled", "_notification")
+
+    def __init__(
+        self,
+        before: bool = False,
+        disabled: bool = False,
+        notification: str | None = None,
+    ) -> None:
+        self._before = before
+        self._disabled = disabled
+        self._notification = notification
+
+    async def __call__(
+        self,
+        update: MessageCallback,
+        ctx: Ctx,
+        next: NextMiddleware[MessageCallback],
+    ) -> Any:
+        answer = CallbackAnswer(
+            disabled=self._disabled,
+            before=self._before,
+            notification=self._notification,
+        )
+        ctx[CALLBACK_ANSWER_KEY] = answer
+
+        if answer.before and not answer.disabled:
+            await self._answer(update, answer)
+
+        result = await next(ctx)
+
+        if not answer.disabled and not answer.answered:
+            await self._answer(update, answer)
+
+        return result
+
+    async def _answer(self, update: MessageCallback, answer: CallbackAnswer) -> None:
+        if answer.notification is not None:
+            await update.answer(notification=answer.notification)
+        else:
+            await update.answer()
+        answer.answered = True

--- a/src/maxo/utils/callback_answer.py
+++ b/src/maxo/utils/callback_answer.py
@@ -1,15 +1,14 @@
-from dataclasses import dataclass
 from typing import Any
 
 from maxo.routing.ctx import Ctx
 from maxo.routing.interfaces.middleware import BaseMiddleware, NextMiddleware
 from maxo.routing.updates.message_callback import MessageCallback
+from maxo.types import MaxoType
 
 CALLBACK_ANSWER_KEY = "callback_answer"
 
 
-@dataclass(slots=True)
-class CallbackAnswer:
+class CallbackAnswer(MaxoType):
     """
     Управление авто-ответом на колбэк из хендлера.
 

--- a/tests/maxo/utils/test_callback_answer.py
+++ b/tests/maxo/utils/test_callback_answer.py
@@ -1,10 +1,14 @@
 from typing import cast
 from unittest.mock import AsyncMock
 
+import pytest
+
 from maxo.routing.ctx import Ctx
 from maxo.routing.updates.message_callback import MessageCallback
 from maxo.utils.callback_answer import (
     CALLBACK_ANSWER_KEY,
+    CallbackAnswer,
+    CallbackAnswerException,
     CallbackAnswerMiddleware,
 )
 
@@ -64,3 +68,51 @@ async def test_no_double_answer_when_before() -> None:
     mw = CallbackAnswerMiddleware(before=True)
     await mw(cast(MessageCallback, update), Ctx({}), _next_ok)
     update.answer.assert_awaited_once_with()
+
+
+async def test_answers_even_when_handler_raises() -> None:
+    update = AsyncMock()
+
+    async def next_boom(ctx: Ctx) -> str:
+        raise RuntimeError("boom")
+
+    mw = CallbackAnswerMiddleware()
+    with pytest.raises(RuntimeError, match="boom"):
+        await mw(cast(MessageCallback, update), Ctx({}), next_boom)
+
+    update.answer.assert_awaited_once_with()
+
+
+async def test_disabled_handler_no_answer_on_exception() -> None:
+    update = AsyncMock()
+
+    async def next_boom(ctx: Ctx) -> str:
+        ctx[CALLBACK_ANSWER_KEY].disabled = True
+        raise RuntimeError("boom")
+
+    mw = CallbackAnswerMiddleware()
+    with pytest.raises(RuntimeError, match="boom"):
+        await mw(cast(MessageCallback, update), Ctx({}), next_boom)
+
+    update.answer.assert_not_awaited()
+
+
+async def test_mutation_after_answer_raises() -> None:
+    answer = CallbackAnswer(answered=True)
+
+    with pytest.raises(CallbackAnswerException):
+        answer.disabled = True
+    with pytest.raises(CallbackAnswerException):
+        answer.notification = "late"
+    with pytest.raises(CallbackAnswerException):
+        answer.before = True
+
+
+async def test_mutation_before_answer_allowed() -> None:
+    answer = CallbackAnswer()
+
+    answer.disabled = True
+    answer.notification = "ok"
+    assert answer.disabled is True
+    assert answer.notification == "ok"
+    assert answer.answered is False

--- a/tests/maxo/utils/test_callback_answer.py
+++ b/tests/maxo/utils/test_callback_answer.py
@@ -1,0 +1,66 @@
+from typing import cast
+from unittest.mock import AsyncMock
+
+from maxo.routing.ctx import Ctx
+from maxo.routing.updates.message_callback import MessageCallback
+from maxo.utils.callback_answer import (
+    CALLBACK_ANSWER_KEY,
+    CallbackAnswerMiddleware,
+)
+
+
+async def _next_ok(ctx: Ctx) -> str:
+    return "OK"
+
+
+async def test_answers_after_handler_by_default() -> None:
+    update = AsyncMock()
+    mw = CallbackAnswerMiddleware()
+    result = await mw(cast(MessageCallback, update), Ctx({}), _next_ok)
+    assert result == "OK"
+    update.answer.assert_awaited_once_with()
+
+
+async def test_before_answers_before_handler() -> None:
+    order: list[str] = []
+    update = AsyncMock()
+    update.answer = AsyncMock(side_effect=lambda **_: order.append("answer"))
+
+    async def next_fn(ctx: Ctx) -> str:
+        order.append("handler")
+        return "OK"
+
+    mw = CallbackAnswerMiddleware(before=True)
+    await mw(cast(MessageCallback, update), Ctx({}), next_fn)
+    assert order == ["answer", "handler"]
+
+
+async def test_handler_can_disable() -> None:
+    update = AsyncMock()
+
+    async def next_fn(ctx: Ctx) -> str:
+        ctx[CALLBACK_ANSWER_KEY].disabled = True
+        return "OK"
+
+    mw = CallbackAnswerMiddleware()
+    await mw(cast(MessageCallback, update), Ctx({}), next_fn)
+    update.answer.assert_not_awaited()
+
+
+async def test_handler_can_change_notification() -> None:
+    update = AsyncMock()
+
+    async def next_fn(ctx: Ctx) -> str:
+        ctx[CALLBACK_ANSWER_KEY].notification = "done"
+        return "OK"
+
+    mw = CallbackAnswerMiddleware()
+    await mw(cast(MessageCallback, update), Ctx({}), next_fn)
+    update.answer.assert_awaited_once_with(notification="done")
+
+
+async def test_no_double_answer_when_before() -> None:
+    update = AsyncMock()
+    mw = CallbackAnswerMiddleware(before=True)
+    await mw(cast(MessageCallback, update), Ctx({}), _next_ok)
+    update.answer.assert_awaited_once_with()


### PR DESCRIPTION
## Описание

Порт aiogram inner-`CallbackAnswerMiddleware` в `maxo.utils.callback_answer` (#67). Автоматически отвечает на колбэк после (или до) хендлера.

**Затык:** в maxo нет механизма flags (`get_flag` / `flags={}`), на котором держится конфиг aiogram-версии. Решение без порта flags: middleware кладёт мутабельный `CallbackAnswer` в `ctx`; хендлер, объявивший параметр `callback_answer: CallbackAnswer`, получает его и может мутировать (отключить, сменить текст). Дефолты задаются в конструкторе middleware.

```python
from maxo.utils.callback_answer import CallbackAnswer, CallbackAnswerMiddleware

dp.message_callback.middleware.inner.add(CallbackAnswerMiddleware())

@dp.message_callback(...)
async def handler(update: MessageCallback, callback_answer: CallbackAnswer) -> None:
    callback_answer.notification = "Готово"
```

## Тесты

5 тестов: ответ после хендлера по умолчанию, `before=True`, отключение из хендлера, смена текста, отсутствие двойного ответа.

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен middleware для автоматического ответа на callback-запросы.
  * Поддерживается пустой ответ или уведомление с заданным текстом.
  * Ответ можно отправить до или после обработчика, а также отключить из обработчика.
  * Изменения параметров ответа доступны до его отправки.

* **Документация**
  * Добавлена подробная документация и навигационная ссылка по новой функциональности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->