### PR TITLE
Алиас `MediaAttachment.file_id` к `media_id`

### DIFF
--- a/src/maxo/dialogs/api/entities/media.py
+++ b/src/maxo/dialogs/api/entities/media.py
@@ -34,7 +34,7 @@ class MediaAttachment:
                  потому что в aiogram_dialog используется `file_id`.
                  Приоритет у `media_id`
         """
-        media_id = media_id or file_id
+        media_id = media_id if media_id is not None else file_id
         if not (url or path or media_id):
             raise ValueError("Neither url nor path nor media_id are provided")
         self.type = type

--- a/src/maxo/dialogs/api/entities/media.py
+++ b/src/maxo/dialogs/api/entities/media.py
@@ -23,9 +23,18 @@ class MediaAttachment:
         url: str | None = None,
         path: Path | str | None = None,
         media_id: MediaId | None = None,
+        file_id: MediaId | None = None,
         use_pipe: bool = False,
         **kwargs: Any,
     ) -> None:
+        """
+        Медиа аттачмент, которые хавают диалоги.
+
+        file_id: Алиас к `media_id`,
+                 потому что в aiogram_dialog используется `file_id`.
+                 Приоритет у `media_id`
+        """
+        media_id = media_id or file_id
         if not (url or path or media_id):
             raise ValueError("Neither url nor path nor media_id are provided")
         self.type = type
@@ -34,6 +43,10 @@ class MediaAttachment:
         self.media_id = media_id
         self.use_pipe = use_pipe
         self.kwargs = kwargs
+
+    @property
+    def file_id(self) -> MediaId | None:
+        return self.media_id
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, MediaAttachment):


### PR DESCRIPTION
# Описание

Почему-то в `maxo.dialogs` в `MediaAttachment` используется поле `media_id` для `MediaId`, а в оригинальных используется `file_id`

## Тип изменения

Удалите неактуальные варианты. Актуальные варианты отметье галочкой

- [x] Новый функционал (некритическое изменение, добавляющее функциональность)

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код полностью написан мной без использования нейросетей


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена поддержка альтернативного параметра `file_id` для идентификации медиа-вложений, с приоритетом для `media_id`.
  * Появилось новое свойство `file_id`, возвращающее текущее значение идентификатора вложения.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->