### PR TITLE
Фикс пустого `MessageCreated.message`

### DIFF
--- a/src/maxo/routing/mixins/message.py
+++ b/src/maxo/routing/mixins/message.py
@@ -19,10 +19,15 @@ if TYPE_CHECKING:
 class MessageMethodsFacade(ChatMethodsFacade):
     __slots__ = ()
 
-    @property
-    @abstractmethod
-    def message(self) -> "Message":
-        raise NotImplementedError
+    if TYPE_CHECKING:
+
+        @property
+        @abstractmethod
+        def message(self) -> "Message":
+            raise NotImplementedError
+
+    else:
+        message: "Message"
 
     @property
     def chat_id(self) -> int:

--- a/src/maxo/serialization.py
+++ b/src/maxo/serialization.py
@@ -20,6 +20,7 @@ from maxo.enums import (
     UpdateType,
 )
 from maxo.omit import is_omitted
+from maxo.routing.mixins import message
 from maxo.routing.updates import (
     BotAddedToChat,
     BotRemovedFromChat,
@@ -173,6 +174,7 @@ def _create_retort(*, defaults: BotDefaults | None = None) -> Retort:
             return datetime.min.replace(tzinfo=UTC)
 
     exec_type_checking(base)
+    exec_type_checking(message)
 
     return DEFAULT_RETORT.extend(
         recipe=[

--- a/tests/maxo/test_serialization.py
+++ b/tests/maxo/test_serialization.py
@@ -1,4 +1,5 @@
 import pytest
+from adaptix.load_error import LoadError
 
 from maxo import Bot
 from maxo.bot.defaults import BotDefaults
@@ -7,7 +8,7 @@ from maxo.enums import TextFormat
 from maxo.errors import AttributeIsEmptyError
 from maxo.omit import Omittable, Omitted, is_omitted
 from maxo.serialization import create_retort, create_retort_with_bot
-from maxo.types import NewMessageBody
+from maxo.types import NewMessageBody, UpdateList
 from maxo.types.base import MaxoType
 
 
@@ -103,3 +104,21 @@ def test_retort_without_bot_no_load_bot() -> None:
 
     dump = retort.dump(my, MyType)
     assert dump == data
+
+
+def test_retort_empty_message() -> None:
+    retort = create_retort(warming_up=False)
+
+    data = {
+        "marker": 1,
+        "updates": [
+            {
+                "update_type": "message_created",
+                "timestamp": 1234567890,
+                "user_locale": "ru",
+            },
+        ],
+    }
+
+    with pytest.raises(LoadError):
+        _ = retort.load(data, UpdateList)

--- a/tests/maxo/test_serialization.py
+++ b/tests/maxo/test_serialization.py
@@ -122,3 +122,27 @@ def test_retort_empty_message() -> None:
 
     with pytest.raises(LoadError):
         _ = retort.load(data, UpdateList)
+
+
+def test_retort_full_message_created_loads_ok() -> None:
+    retort = create_retort(warming_up=False)
+
+    # Полный валидный message_created - убеждаемся, что регрессия не сломала happy path
+    data = {
+        "marker": 1,
+        "updates": [
+            {
+                "update_type": "message_created",
+                "timestamp": 1234567890,
+                "user_locale": "ru",
+                "message": {
+                    "body": {"seq": 1, "mid": "msg-1", "text": "hello"},
+                    "recipient": {"chat_id": 1, "chat_type": "dialog"},
+                    "timestamp": 1234567890,
+                },
+            },
+        ],
+    }
+
+    result = retort.load(data, UpdateList)
+    assert len(result.updates) == 1


### PR DESCRIPTION
# Описание

Фикс лоада `MessageCreated` с `message=<property ...>`, если `message…` не передаётся. \
Возникает при получении ботом голосового сообщения на утро 29.06.2026

<img width="1490" height="672" alt="telegram-cloud-photo-size-2-5337234869970475930-w" src="https://github.com/user-attachments/assets/8d4c7e61-1955-4277-bc70-49b223ccedf1" />

<img width="1662" height="718" alt="telegram-cloud-photo-size-2-5337234869970475931-w" src="https://github.com/user-attachments/assets/b4a5e8e8-f051-4b43-ac54-a3f656f8c500" />

## Тип изменения

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего собственного кода
- [x] Я добавил тесты, которые доказывают, что мое исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код полностью написан мной без использования нейросетей


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Улучшена валидация сообщений при сериализации и загрузке: при обработке сообщений для `UpdateList` некорректные/неполные входные данные теперь корректно приводят к ошибке (вместо неожиданного поведения).
* **Tests**
  * Добавлены тесты для загрузки пустого/неполного сообщения (`marker` без обязательных полей) и для корректного сценария, где присутствует ровно один update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->