### PR TITLE
fix(routing): AttributeIsEmptyError вместо AttributeError в MessageCallback без message

### DIFF
--- a/docs/pages/botapi/omitted.rst
+++ b/docs/pages/botapi/omitted.rst
@@ -197,6 +197,8 @@ Omitted в объектах ответа
 ``User`` (``last_name``, ``name``), ``VideoAttachment`` (``duration``, ``width``, ``height``)
 и многие другие.
 
+.. _message-callback-none:
+
 ``unsafe_*`` есть и у полей, которые API возвращает как ``null``.
 Главный пример - ``MessageCallback.message``: MAX присылает ``null``, если
 исходное сообщение с клавиатурой удалили до того, как бот получил колбэк.

--- a/docs/pages/botapi/omitted.rst
+++ b/docs/pages/botapi/omitted.rst
@@ -197,6 +197,29 @@ Omitted в объектах ответа
 ``User`` (``last_name``, ``name``), ``VideoAttachment`` (``duration``, ``width``, ``height``)
 и многие другие.
 
+``unsafe_*`` есть и у полей, которые API возвращает как ``null``.
+Главный пример - ``MessageCallback.message``: MAX присылает ``null``, если
+исходное сообщение с клавиатурой удалили до того, как бот получил колбэк.
+
+.. code-block:: python
+
+    from maxo.types import MessageCallback
+
+    @dispatcher.message_callback()
+    async def handler(update: MessageCallback) -> None:
+        if update.message is None:
+            # Сообщения уже нет: остаётся только ответить на сам колбэк
+            await update.callback_answer(notification="Сообщение удалено")
+            return
+
+        # Дальше можно и update.unsafe_message, и методы апдейта
+        await update.answer_text("Кнопка нажата")
+
+Методы, которым нужно исходное сообщение (``send_message``, ``answer_text``,
+``reply``, ``edit_message``, ``delete_message``, а также свойство ``chat_id``),
+при ``message=None`` бросают ``AttributeIsEmptyError``.
+``callback_answer`` работает всегда.
+
 
 Примеры
 -------

--- a/docs/pages/dialogs/widgets.rst
+++ b/docs/pages/dialogs/widgets.rst
@@ -4,6 +4,13 @@
 
 Виджеты - компоненты, из которых строится содержимое окна (``Window``). Все виджеты делятся на текстовые, клавиатурные, медиа-виджеты и поля ввода.
 
+.. note::
+
+    В обработчиках ``on_click`` ``callback.message`` может быть ``None``, если
+    исходное сообщение удалили до того, как бот получил колбэк - тогда
+    ``unsafe_message`` бросит ``AttributeIsEmptyError``.
+    Подробнее в :ref:`разделе про unsafe_* <message-callback-none>`.
+
 Текстовые виджеты
 =================
 
@@ -246,22 +253,6 @@ ConfirmButton
         on_confirm=on_confirm,
         on_cancel=None,    # при отмене просто возвращается primary
     )
-
-.. note::
-
-    ``MessageCallback.message`` может быть ``None``, если исходное сообщение
-    с клавиатурой удалили до того, как бот получил колбэк. Поэтому
-    ``unsafe_message`` (как и ``send_message``, ``reply``, ``edit_message``,
-    ``delete_message``, ``chat_id``) бросает ``AttributeIsEmptyError``.
-    Если сообщения может не быть, проверяйте его явно или отвечайте через
-    ``callback.callback_answer(notification=...)``:
-
-    .. code-block:: python
-
-        if callback.message is not None:
-            await callback.message.answer("Действие подтверждено!")
-        else:
-            await callback.callback_answer(notification="Действие подтверждено!")
 
 Параметры
 ^^^^^^^^^

--- a/docs/pages/dialogs/widgets.rst
+++ b/docs/pages/dialogs/widgets.rst
@@ -247,6 +247,22 @@ ConfirmButton
         on_cancel=None,    # при отмене просто возвращается primary
     )
 
+.. note::
+
+    ``MessageCallback.message`` может быть ``None``, если исходное сообщение
+    с клавиатурой удалили до того, как бот получил колбэк. Поэтому
+    ``unsafe_message`` (как и ``send_message``, ``reply``, ``edit_message``,
+    ``delete_message``, ``chat_id``) бросает ``AttributeIsEmptyError``.
+    Если сообщения может не быть, проверяйте его явно или отвечайте через
+    ``callback.callback_answer(notification=...)``:
+
+    .. code-block:: python
+
+        if callback.message is not None:
+            await callback.message.answer("Действие подтверждено!")
+        else:
+            await callback.callback_answer(notification="Действие подтверждено!")
+
 Параметры
 ^^^^^^^^^
 

--- a/docs/pages/dialogs/widgets.rst
+++ b/docs/pages/dialogs/widgets.rst
@@ -214,14 +214,14 @@ ConfirmButton
         widget: ConfirmButton,
         manager: DialogManager,
     ) -> None:
-        await callback.message.answer("Действие подтверждено!")
+        await callback.unsafe_message.answer("Действие подтверждено!")
 
     async def on_cancel(
         callback: MessageCallback,
         widget: ConfirmButton,
         manager: DialogManager,
     ) -> None:
-        await callback.message.answer("Действие отменено.")
+        await callback.unsafe_message.answer("Действие отменено.")
 
     # Режим с предупредительным текстом (2 шага):
     # primary → warning + [Отмена] [Подтвердить] → on_confirm / on_cancel

--- a/src/maxo/dialogs/context/intent_middleware.py
+++ b/src/maxo/dialogs/context/intent_middleware.py
@@ -55,14 +55,19 @@ FORBIDDEN_STACK_KEY = "aiogd_stack_forbidden"
 
 
 def event_context_from_callback(event: MessageCallback, ctx: Ctx) -> EventContext:
-    recipient = event.message.recipient if event.message is not None else None
+    # Сообщение могли удалить до того, как бот получил колбэк
+    if (message := event.message) is not None:
+        chat_id, chat_type = message.recipient.chat_id, message.recipient.chat_type
+    else:
+        chat_id, chat_type = None, None
+
     return EventContext(
         bot=ctx["bot"],
         user=event.callback.user,
         user_id=event.callback.user.user_id,
-        chat_id=recipient.chat_id if recipient is not None else None,
+        chat_id=chat_id,
         chat=None,
-        chat_type=recipient.chat_type if recipient is not None else None,
+        chat_type=chat_type,
     )
 
 

--- a/src/maxo/dialogs/context/intent_middleware.py
+++ b/src/maxo/dialogs/context/intent_middleware.py
@@ -55,13 +55,14 @@ FORBIDDEN_STACK_KEY = "aiogd_stack_forbidden"
 
 
 def event_context_from_callback(event: MessageCallback, ctx: Ctx) -> EventContext:
+    recipient = event.message.recipient if event.message is not None else None
     return EventContext(
         bot=ctx["bot"],
         user=event.callback.user,
         user_id=event.callback.user.user_id,
-        chat_id=event.unsafe_message.recipient.chat_id,
+        chat_id=recipient.chat_id if recipient is not None else None,
         chat=None,
-        chat_type=event.unsafe_message.recipient.chat_type,
+        chat_type=recipient.chat_type if recipient is not None else None,
     )
 
 

--- a/src/maxo/routing/facades/message_callback.py
+++ b/src/maxo/routing/facades/message_callback.py
@@ -14,8 +14,8 @@ class MessageCallbackFacade(  # type: ignore[misc]
     MessageMethodsFacade,
 ):
     @property
-    def message(self) -> Message:
-        return self._update.unsafe_message
+    def message(self) -> Message | None:
+        return self._update.message
 
     @property
     def callback(self) -> Callback:

--- a/src/maxo/routing/mixins/message.py
+++ b/src/maxo/routing/mixins/message.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, cast
 
 from maxo.enums import MessageLinkType, TextFormat
+from maxo.errors import AttributeIsEmptyError
 from maxo.omit import Omittable, Omitted, is_defined
 from maxo.routing.mixins.attachments import MediaInput
 from maxo.routing.mixins.chat import ChatMethodsFacade
@@ -23,18 +24,29 @@ class MessageMethodsFacade(ChatMethodsFacade):
 
         @property
         @abstractmethod
-        def message(self) -> "Message":
+        def message(self) -> "Message | None":
             raise NotImplementedError
 
     else:
-        message: "Message"
+        message: "Message | None"
+
+    @property
+    def unsafe_message(self) -> "Message":
+        """Сообщение апдейта. Кидает ошибку, если сообщения нет."""
+        if is_defined(self.message):
+            return self.message
+
+        raise AttributeIsEmptyError(
+            obj=self,
+            attr="message",
+        )
 
     @property
     def chat_id(self) -> int:
-        return self.message.recipient.unsafe_chat_id
+        return self.unsafe_message.recipient.unsafe_chat_id
 
     async def delete_message(self) -> SimpleQueryResult:
-        message_id = self.message.body.mid
+        message_id = self.unsafe_message.body.mid
         return await self.bot.delete_message(message_id=message_id)
 
     async def send_message(
@@ -48,8 +60,9 @@ class MessageMethodsFacade(ChatMethodsFacade):
         media: Sequence[MediaInput] | None = None,
         attachments: Sequence[AttachmentsRequests] | None = None,
     ) -> "Message":
-        recipient = self.message.recipient
-        sender = self.message.sender
+        message = self.unsafe_message
+        recipient = message.recipient
+        sender = message.sender
         chat_id, user_id = calculate_chat_id_and_user_id(
             chat_id=recipient.chat_id,
             user_id=sender.user_id if is_defined(sender) else None,
@@ -164,10 +177,11 @@ class MessageMethodsFacade(ChatMethodsFacade):
         format: Omittable[TextFormat | None] = Omitted(),
         attachments: Sequence[AttachmentsRequests] | None = None,
     ) -> SimpleQueryResult:
-        message_id = self.message.body.mid
+        message = self.unsafe_message
+        message_id = message.body.mid
 
         if text is None:
-            text = self.message.body.text
+            text = message.body.text
 
         if attachments is None and keyboard is None and media is None:
             # Для случая, когда не надо редачить аттачменты
@@ -194,7 +208,7 @@ class MessageMethodsFacade(ChatMethodsFacade):
     def _make_new_message_link(self, type: MessageLinkType) -> NewMessageLink:
         return NewMessageLink(
             type=type,
-            mid=self.message.body.mid,
+            mid=self.unsafe_message.body.mid,
         )
 
     async def get_message_by_id(self, message_id: str) -> "Message":

--- a/src/maxo/routing/mixins/message.py
+++ b/src/maxo/routing/mixins/message.py
@@ -32,7 +32,6 @@ class MessageMethodsFacade(ChatMethodsFacade):
 
     @property
     def unsafe_message(self) -> "Message":
-        """Сообщение апдейта. Кидает ошибку, если сообщения нет."""
         if is_defined(self.message):
             return self.message
 

--- a/src/maxo/routing/mixins/message.py
+++ b/src/maxo/routing/mixins/message.py
@@ -32,7 +32,12 @@ class MessageMethodsFacade(ChatMethodsFacade):
 
     @property
     def unsafe_message(self) -> "Message":
-        """Сообщение апдейта. Кидает ошибку, если сообщения нет."""
+        """
+        Сообщение апдейта. Кидает ошибку, если сообщения нет.
+
+        Сообщения может не быть только у `MessageCallback`: MAX присылает
+        `null`, если исходное сообщение удалили до получения колбэка.
+        """
         if is_defined(self.message):
             return self.message
 

--- a/src/maxo/routing/mixins/message.py
+++ b/src/maxo/routing/mixins/message.py
@@ -32,6 +32,7 @@ class MessageMethodsFacade(ChatMethodsFacade):
 
     @property
     def unsafe_message(self) -> "Message":
+        """Сообщение апдейта. Кидает ошибку, если сообщения нет."""
         if is_defined(self.message):
             return self.message
 

--- a/src/maxo/types/message_callback.py
+++ b/src/maxo/types/message_callback.py
@@ -26,21 +26,11 @@ class MessageCallback(MaxUpdate, CallbackMethodsFacade, MessageMethodsFacade):  
 
     callback: Callback
 
-    message: Message | None = None  # type: ignore[assignment]
+    message: Message | None = None
     """Изначальное сообщение, содержащее встроенную клавиатуру. Может быть `null`, если оно было удалено к моменту, когда бот получил это событие"""
 
     user_locale: Omittable[str | None] = Omitted()
     """Текущий язык пользователя в формате IETF BCP 47"""
-
-    @property
-    def unsafe_message(self) -> Message:
-        if is_defined(self.message):
-            return self.message
-
-        raise AttributeIsEmptyError(
-            obj=self,
-            attr="message",
-        )
 
     @property
     def unsafe_user_locale(self) -> str:

--- a/src/maxo/types/message_callback.py
+++ b/src/maxo/types/message_callback.py
@@ -33,6 +33,16 @@ class MessageCallback(MaxUpdate, CallbackMethodsFacade, MessageMethodsFacade):  
     """Текущий язык пользователя в формате IETF BCP 47"""
 
     @property
+    def unsafe_message(self) -> Message:
+        if is_defined(self.message):
+            return self.message
+
+        raise AttributeIsEmptyError(
+            obj=self,
+            attr="message",
+        )
+
+    @property
     def unsafe_user_locale(self) -> str:
         if is_defined(self.user_locale):
             return self.user_locale

--- a/tests/maxo/routing/test_facades.py
+++ b/tests/maxo/routing/test_facades.py
@@ -64,10 +64,10 @@ def message() -> Message:
     )
 
 
-def callback_update(with_message: bool = True) -> MessageCallback:
+def callback_update(msg: Message | None = None) -> MessageCallback:
     return MessageCallback(
         timestamp=NOW,
-        message=message() if with_message else None,
+        message=msg,
         callback=Callback(
             callback_id="cb",
             user=user(),
@@ -151,7 +151,7 @@ CASES: list[tuple[Any, Any, tuple[str, ...]]] = [
     ),
     (
         MessageCallbackFacade,
-        callback_update(),
+        callback_update(message()),
         ("message", "callback", "user_locale", "callback_id", "payload", "user"),
     ),
 ]
@@ -173,40 +173,30 @@ def test_facade_delegates_properties(
         assert getattr(facade, name) == getattr(update, name), name
 
 
-class TestMessageCallbackFacadeWithoutMessage:
-    """Колбэк по удалённому сообщению: `message` - `None`, `unsafe_message` - ошибка."""
+def test_callback_facade_message_is_none_without_message() -> None:
+    """MAX присылает `message=null`, если сообщение удалили до колбэка."""
+    facade = MessageCallbackFacade(bot=MagicMock(), update=callback_update())
 
-    @pytest.fixture
-    def facade(self) -> MessageCallbackFacade:
-        return MessageCallbackFacade(
-            bot=MagicMock(),
-            update=callback_update(with_message=False),
-        )
+    assert facade.message is None
 
-    def test_message_is_none(self, facade: MessageCallbackFacade) -> None:
-        assert facade.message is None
+    with pytest.raises(AttributeIsEmptyError):
+        _ = facade.unsafe_message
 
-    def test_unsafe_message_raises(self, facade: MessageCallbackFacade) -> None:
-        with pytest.raises(AttributeIsEmptyError):
-            _ = facade.unsafe_message
 
-    def test_chat_id_raises(self, facade: MessageCallbackFacade) -> None:
-        with pytest.raises(AttributeIsEmptyError):
-            _ = facade.chat_id
+async def test_callback_facade_methods_raise_without_message() -> None:
+    """Методы миксина ходят в сообщение через фасадную пропертю `message`."""
+    facade = MessageCallbackFacade(bot=MagicMock(), update=callback_update())
 
-    async def test_send_message_raises(self, facade: MessageCallbackFacade) -> None:
-        with pytest.raises(AttributeIsEmptyError):
-            await facade.send_message("hi")
+    with pytest.raises(AttributeIsEmptyError):
+        await facade.send_message("hi")
 
-    async def test_delete_message_raises(self, facade: MessageCallbackFacade) -> None:
-        with pytest.raises(AttributeIsEmptyError):
-            await facade.delete_message()
 
-    def test_unsafe_message_returns_message_when_present(self) -> None:
-        update = callback_update()
-        facade = MessageCallbackFacade(bot=MagicMock(), update=update)
+def test_callback_facade_unsafe_message_returns_message() -> None:
+    update = callback_update(message())
 
-        assert facade.unsafe_message is update.message
+    facade = MessageCallbackFacade(bot=MagicMock(), update=update)
+
+    assert facade.unsafe_message is update.message
 
 
 def test_base_facade_exposes_update() -> None:

--- a/tests/maxo/routing/test_facades.py
+++ b/tests/maxo/routing/test_facades.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from maxo.enums import ChatType
+from maxo.errors import AttributeIsEmptyError
 from maxo.routing.facades import (
     BotAddedToChatFacade,
     BotRemovedFromChatFacade,
@@ -63,10 +64,10 @@ def message() -> Message:
     )
 
 
-def callback_update() -> MessageCallback:
+def callback_update(with_message: bool = True) -> MessageCallback:
     return MessageCallback(
         timestamp=NOW,
-        message=message(),
+        message=message() if with_message else None,
         callback=Callback(
             callback_id="cb",
             user=user(),
@@ -170,6 +171,42 @@ def test_facade_delegates_properties(
 
     for name in properties:
         assert getattr(facade, name) == getattr(update, name), name
+
+
+class TestMessageCallbackFacadeWithoutMessage:
+    """Колбэк по удалённому сообщению: `message` - `None`, `unsafe_message` - ошибка."""
+
+    @pytest.fixture
+    def facade(self) -> MessageCallbackFacade:
+        return MessageCallbackFacade(
+            bot=MagicMock(),
+            update=callback_update(with_message=False),
+        )
+
+    def test_message_is_none(self, facade: MessageCallbackFacade) -> None:
+        assert facade.message is None
+
+    def test_unsafe_message_raises(self, facade: MessageCallbackFacade) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            _ = facade.unsafe_message
+
+    def test_chat_id_raises(self, facade: MessageCallbackFacade) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            _ = facade.chat_id
+
+    async def test_send_message_raises(self, facade: MessageCallbackFacade) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            await facade.send_message("hi")
+
+    async def test_delete_message_raises(self, facade: MessageCallbackFacade) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            await facade.delete_message()
+
+    def test_unsafe_message_returns_message_when_present(self) -> None:
+        update = callback_update()
+        facade = MessageCallbackFacade(bot=MagicMock(), update=update)
+
+        assert facade.unsafe_message is update.message
 
 
 def test_base_facade_exposes_update() -> None:

--- a/tests/maxo/types/conftest.py
+++ b/tests/maxo/types/conftest.py
@@ -1,0 +1,34 @@
+from maxo.enums import ChatType
+from maxo.types import Callback, Message, MessageBody, Recipient, User
+from tests.constants import NOW
+
+
+def make_user() -> User:
+    return User(
+        user_id=1,
+        first_name="Alice",
+        last_name="Tester",
+        name="Alice T.",
+        username="alice",
+        is_bot=False,
+        last_activity_time=NOW,
+    )
+
+
+def make_message(**kwargs: object) -> Message:
+    data = {
+        "body": MessageBody(mid="mid", seq=7, text="hello"),
+        "recipient": Recipient(chat_type=ChatType.CHAT, chat_id=10),
+        "timestamp": NOW,
+    }
+    data.update(kwargs)
+    return Message(**data)  # type: ignore[arg-type]
+
+
+def make_callback() -> Callback:
+    return Callback(
+        callback_id="cb",
+        timestamp=NOW,
+        user=make_user(),
+        payload="payload",
+    )

--- a/tests/maxo/types/test_accessors.py
+++ b/tests/maxo/types/test_accessors.py
@@ -83,6 +83,8 @@ from maxo.types import (
 )
 from tests.constants import NOW
 
+from .conftest import make_callback, make_message, make_user
+
 TOKEN = "attachment-token"  # noqa: S105
 PHOTO_ID = "photo-token"
 PHOTO_ATTACHMENT_ID = "photo-attachment"
@@ -91,18 +93,6 @@ UPLOAD_ID = "upload-token"
 UPLOADED_ID = "uploaded-token"
 VIDEO_ID = "video-token"
 DETAILS_ID = "details-token"
-
-
-def make_user() -> User:
-    return User(
-        user_id=1,
-        first_name="Alice",
-        last_name="Tester",
-        name="Alice T.",
-        username="alice",
-        is_bot=False,
-        last_activity_time=NOW,
-    )
 
 
 def make_chat(**kwargs: object) -> Chat:
@@ -116,16 +106,6 @@ def make_chat(**kwargs: object) -> Chat:
     }
     data.update(kwargs)
     return Chat(**data)  # type: ignore[arg-type]
-
-
-def make_message(**kwargs: object) -> Message:
-    data = {
-        "body": MessageBody(mid="mid", seq=7, text="hello"),
-        "recipient": Recipient(chat_type=ChatType.CHAT, chat_id=10),
-        "timestamp": NOW,
-    }
-    data.update(kwargs)
-    return Message(**data)  # type: ignore[arg-type]
 
 
 def test_user_accessors() -> None:
@@ -1276,15 +1256,6 @@ def test_missing_optional_fields_raise_for_unsafe_accessors() -> None:
         _ = message.unsafe_stat
     with pytest.raises(AttributeIsEmptyError):
         _ = message.unsafe_url
-
-
-def make_callback() -> Callback:
-    return Callback(
-        callback_id="cb",
-        timestamp=NOW,
-        user=make_user(),
-        payload="payload",
-    )
 
 
 def test_bot_stopped_unsafe_user_locale() -> None:

--- a/tests/maxo/types/test_message_callback.py
+++ b/tests/maxo/types/test_message_callback.py
@@ -5,33 +5,16 @@ import pytest
 from maxo.enums import ChatType
 from maxo.errors import AttributeIsEmptyError
 from maxo.types import (
-    Callback,
     Message,
     MessageBody,
     MessageCallback,
     Recipient,
     SendMessageResult,
     SimpleQueryResult,
-    User,
 )
 from tests.constants import NOW
 
-
-def make_user() -> User:
-    return User(user_id=5, is_bot=False, first_name="U", last_activity_time=NOW)
-
-
-def make_callback() -> Callback:
-    return Callback(callback_id="cb1", timestamp=NOW, user=make_user())
-
-
-def make_message() -> Message:
-    return Message(
-        timestamp=NOW,
-        recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=5),
-        body=MessageBody(mid="m1", seq=1, text="hi"),
-        sender=make_user(),
-    )
+from .conftest import make_callback, make_message
 
 
 @pytest.fixture
@@ -100,7 +83,7 @@ class TestMessageCallbackWithoutMessage:
         await callback_without_message.callback_answer(notification="ok")
 
         bot.answer_on_callback.assert_awaited_once_with(
-            callback_id="cb1",
+            callback_id="cb",
             notification="ok",
             message=None,
         )
@@ -139,4 +122,4 @@ class TestMessageCallbackWithMessage:
     ) -> None:
         await callback_with_message.delete_message()
 
-        bot.delete_message.assert_awaited_once_with(message_id="m1")
+        bot.delete_message.assert_awaited_once_with(message_id="mid")

--- a/tests/maxo/types/test_message_callback.py
+++ b/tests/maxo/types/test_message_callback.py
@@ -1,0 +1,142 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from maxo.enums import ChatType
+from maxo.errors import AttributeIsEmptyError
+from maxo.types import (
+    Callback,
+    Message,
+    MessageBody,
+    MessageCallback,
+    Recipient,
+    SendMessageResult,
+    SimpleQueryResult,
+    User,
+)
+from tests.constants import NOW
+
+
+def make_user() -> User:
+    return User(user_id=5, is_bot=False, first_name="U", last_activity_time=NOW)
+
+
+def make_callback() -> Callback:
+    return Callback(callback_id="cb1", timestamp=NOW, user=make_user())
+
+
+def make_message() -> Message:
+    return Message(
+        timestamp=NOW,
+        recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=5),
+        body=MessageBody(mid="m1", seq=1, text="hi"),
+        sender=make_user(),
+    )
+
+
+@pytest.fixture
+def bot() -> MagicMock:
+    sent = Message(
+        timestamp=NOW,
+        recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=5),
+        body=MessageBody(mid="m2", seq=2, text="sent"),
+    )
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=SendMessageResult(message=sent))
+    bot.edit_message = AsyncMock(return_value=SimpleQueryResult(success=True))
+    bot.delete_message = AsyncMock(return_value=SimpleQueryResult(success=True))
+    bot.answer_on_callback = AsyncMock(return_value=SimpleQueryResult(success=True))
+    return bot
+
+
+@pytest.fixture
+def callback_without_message(bot: MagicMock) -> MessageCallback:
+    update = MessageCallback(callback=make_callback(), message=None, timestamp=NOW)
+    update.as_(bot)
+    return update
+
+
+class TestMessageCallbackWithoutMessage:
+    def test_chat_id_raises_attribute_is_empty(
+        self,
+        callback_without_message: MessageCallback,
+    ) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            _ = callback_without_message.chat_id
+
+    async def test_delete_message_raises_attribute_is_empty(
+        self,
+        callback_without_message: MessageCallback,
+    ) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            await callback_without_message.delete_message()
+
+    async def test_send_message_raises_attribute_is_empty(
+        self,
+        callback_without_message: MessageCallback,
+    ) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            await callback_without_message.send_message("hi")
+
+    async def test_reply_raises_attribute_is_empty(
+        self,
+        callback_without_message: MessageCallback,
+    ) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            await callback_without_message.reply("hi")
+
+    async def test_edit_message_raises_attribute_is_empty(
+        self,
+        callback_without_message: MessageCallback,
+    ) -> None:
+        with pytest.raises(AttributeIsEmptyError):
+            await callback_without_message.edit_message("hi")
+
+    async def test_callback_answer_works_without_message(
+        self,
+        callback_without_message: MessageCallback,
+        bot: MagicMock,
+    ) -> None:
+        await callback_without_message.callback_answer(notification="ok")
+
+        bot.answer_on_callback.assert_awaited_once_with(
+            callback_id="cb1",
+            notification="ok",
+            message=None,
+        )
+
+
+class TestMessageCallbackWithMessage:
+    @pytest.fixture
+    def callback_with_message(self, bot: MagicMock) -> MessageCallback:
+        update = MessageCallback(
+            callback=make_callback(),
+            message=make_message(),
+            timestamp=NOW,
+        )
+        update.as_(bot)
+        return update
+
+    def test_chat_id_comes_from_recipient(
+        self,
+        callback_with_message: MessageCallback,
+    ) -> None:
+        assert callback_with_message.chat_id == 10
+
+    async def test_send_message_passes_chat_id(
+        self,
+        callback_with_message: MessageCallback,
+        bot: MagicMock,
+    ) -> None:
+        await callback_with_message.send_message("hello")
+
+        assert bot.send_message.await_args.kwargs["chat_id"] == 10
+
+    async def test_delete_message_uses_mid(
+        self,
+        callback_with_message: MessageCallback,
+        bot: MagicMock,
+    ) -> None:
+        await callback_with_message.delete_message()
+
+        bot.delete_message.assert_awaited_once_with(message_id="m1")

--- a/tests/maxo/types/test_message_callback.py
+++ b/tests/maxo/types/test_message_callback.py
@@ -14,7 +14,7 @@ from maxo.types import (
 )
 from tests.constants import NOW
 
-from .conftest import make_callback, make_message
+from .conftest import make_callback, make_message, make_user
 
 
 @pytest.fixture
@@ -94,7 +94,11 @@ class TestMessageCallbackWithMessage:
     def callback_with_message(self, bot: MagicMock) -> MessageCallback:
         update = MessageCallback(
             callback=make_callback(),
-            message=make_message(),
+            # Личка с отправителем, чтобы проверять и chat_id, и user_id.
+            message=make_message(
+                recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=1),
+                sender=make_user(),
+            ),
             timestamp=NOW,
         )
         update.as_(bot)
@@ -106,7 +110,7 @@ class TestMessageCallbackWithMessage:
     ) -> None:
         assert callback_with_message.chat_id == 10
 
-    async def test_send_message_passes_chat_id(
+    async def test_send_message_passes_chat_id_and_user_id(
         self,
         callback_with_message: MessageCallback,
         bot: MagicMock,
@@ -114,6 +118,7 @@ class TestMessageCallbackWithMessage:
         await callback_with_message.send_message("hello")
 
         assert bot.send_message.await_args.kwargs["chat_id"] == 10
+        assert bot.send_message.await_args.kwargs["user_id"] == 1
 
     async def test_delete_message_uses_mid(
         self,

--- a/tests/maxo/types/test_message_callback.py
+++ b/tests/maxo/types/test_message_callback.py
@@ -94,9 +94,9 @@ class TestMessageCallbackWithMessage:
     def callback_with_message(self, bot: MagicMock) -> MessageCallback:
         update = MessageCallback(
             callback=make_callback(),
-            # Личка с отправителем, чтобы проверять и chat_id, и user_id.
+            # Личка: chat_id берётся из recipient, user_id - из sender.
             message=make_message(
-                recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=1),
+                recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10),
                 sender=make_user(),
             ),
             timestamp=NOW,

--- a/tests/maxo_dialog/test_intent_middleware.py
+++ b/tests/maxo_dialog/test_intent_middleware.py
@@ -29,6 +29,7 @@ from maxo.dialogs.context.intent_middleware import (
     IntentMiddlewareFactory,
     event_context_from_aiogd,
     event_context_from_bot_started,
+    event_context_from_callback,
     event_context_from_error,
     event_context_from_user_added_to_chat,
 )
@@ -83,6 +84,20 @@ def make_message_callback(payload: str = "data") -> MessageCallback:
             recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=1),
             body=MessageBody(mid="m", seq=1),
         ),
+        callback=Callback(
+            callback_id="c",
+            user=make_user(),
+            timestamp=NOW,
+            payload=payload,
+        ),
+    )
+
+
+def make_message_callback_without_message(payload: str = "data") -> MessageCallback:
+    """Колбэк с удалённым исходным сообщением: `message` приходит как `null`."""
+    return MessageCallback(
+        timestamp=NOW,
+        message=None,
         callback=Callback(
             callback_id="c",
             user=make_user(),
@@ -216,6 +231,23 @@ class TestEventContextBuilders:
         assert context.chat_id == 10
         assert context.user_id == 1
 
+    def test_from_callback(self) -> None:
+        context = event_context_from_callback(make_message_callback(), make_ctx())  # type: ignore[arg-type]
+
+        assert context.chat_id == 10
+        assert context.chat_type is ChatType.DIALOG
+        assert context.user_id == 1
+
+    def test_from_callback_without_message(self) -> None:
+        event = make_message_callback_without_message()
+
+        context = event_context_from_callback(event, make_ctx())  # type: ignore[arg-type]
+
+        assert context.chat_id is None
+        assert context.chat_type is None
+        assert context.user_id == 1
+        assert context.user is event.callback.user
+
 
 class TestEventContextFromError:
     @pytest.mark.parametrize(
@@ -223,6 +255,7 @@ class TestEventContextFromError:
         [
             make_message_created,
             make_message_callback,
+            make_message_callback_without_message,
             make_aiogd_event,
             make_bot_started,
             make_bot_stopped,
@@ -308,6 +341,20 @@ class TestIntentMiddlewareFactory:
 
         assert ctx[PAYLOAD_KEY] == "plain"
         assert ctx[CALLBACK_DATA_KEY] == "plain"
+
+    async def test_process_callback_without_message(self) -> None:
+        ctx = make_ctx()
+        next_ = AsyncMock(return_value="ok")
+
+        result = await make_factory().process_callback(
+            make_message_callback_without_message("plain"),
+            ctx,  # type: ignore[arg-type]
+            next_,
+        )
+
+        assert result == "ok"
+        next_.assert_awaited_once()
+        assert ctx[EVENT_CONTEXT_KEY].chat_id is None
 
     async def test_process_aiogd_update_by_stack(self) -> None:
         ctx = make_ctx()

--- a/tests/maxo_dialog/test_intent_middleware.py
+++ b/tests/maxo_dialog/test_intent_middleware.py
@@ -76,6 +76,15 @@ def make_ctx(bot: Any = None) -> dict[Any, Any]:
     }
 
 
+def make_callback(payload: str = "data") -> Callback:
+    return Callback(
+        callback_id="c",
+        user=make_user(),
+        timestamp=NOW,
+        payload=payload,
+    )
+
+
 def make_message_callback(payload: str = "data") -> MessageCallback:
     return MessageCallback(
         timestamp=NOW,
@@ -84,12 +93,7 @@ def make_message_callback(payload: str = "data") -> MessageCallback:
             recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=10, user_id=1),
             body=MessageBody(mid="m", seq=1),
         ),
-        callback=Callback(
-            callback_id="c",
-            user=make_user(),
-            timestamp=NOW,
-            payload=payload,
-        ),
+        callback=make_callback(payload),
     )
 
 
@@ -98,12 +102,7 @@ def make_message_callback_without_message(payload: str = "data") -> MessageCallb
     return MessageCallback(
         timestamp=NOW,
         message=None,
-        callback=Callback(
-            callback_id="c",
-            user=make_user(),
-            timestamp=NOW,
-            payload=payload,
-        ),
+        callback=make_callback(payload),
     )
 
 


### PR DESCRIPTION
# Описание

`MessageCallback.message` может быть `None` (колбэк по удалённому сообщению - задокументированный сценарий MAX API), но методы `MessageMethodsFacade` лезли в `self.message.*` без защиты и падали с голым `AttributeError: 'NoneType' ...`.

Closes #119

## Изменения

- `MessageMethodsFacade` честно объявляет `message: Message | None`; добавлен `unsafe_message` (паттерн `unsafe_*` + `AttributeIsEmptyError`), все методы фасада (`chat_id`, `send_message`, `reply`, `edit_message`, `delete_message`, ...) ходят через него. При `message=None` теперь ловимая типизированная `AttributeIsEmptyError` вместо голого `AttributeError` (`AttributeIsEmptyError` наследует `AttributeError`, существующие `except` продолжают работать).
- dialogs: `event_context_from_callback` не падает на колбэке по удалённому сообщению - `chat_id`/`chat_type` в `EventContext` становятся `None`.
- Убран ставший лишним `type: ignore[assignment]` на поле `MessageCallback.message`.
- `callback_answer` при `message=None` работает как раньше.
- Дока `omitted.rst`/`widgets.rst` про `unsafe_message`, тесты на все методы фасада без сообщения, общий `conftest.py` для `tests/maxo/types`.

## Breaking changes

- **!** `MessageCallbackFacade.message` возвращает `Message | None` и больше не кидает исключение при отсутствии сообщения - для гарантированного доступа используйте `unsafe_message`.
- **!** Тип `MessageMethodsFacade.message` расширен до `Message | None` - кастомные наследники фасада под strict-типизацией могут потребовать правок.

## Тип изменения

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)

# Как это было протестировано?

`uv run pytest` (1559 на смерженном master), ruff, mypy strict, slotscheck - зелёные (Python 3.14, macOS).

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего кода
- [x] Я внёс соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что моё исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека
