### PR TITLE
Фикс передачи `None` (`null`) в квери параметры

### DIFF
--- a/src/maxo/serialization.py
+++ b/src/maxo/serialization.py
@@ -12,6 +12,7 @@ from unihttp.serializers.adaptix.serialize import DEFAULT_RETORT
 from maxo._internal.adaptix import concat_provider, has_tag_provider, is_subclass
 from maxo.bot.defaults import BotDefaults
 from maxo.bot.methods import EditMessage, SendMessage
+from maxo.bot.methods.base import MaxoMethod
 from maxo.bot.warming_up import WarmingUpType, warming_up_retort
 from maxo.enums import (
     AttachmentRequestType,
@@ -20,7 +21,7 @@ from maxo.enums import (
     MarkupElementType,
     UpdateType,
 )
-from maxo.omit import is_omitted
+from maxo.omit import Omitted, is_omitted
 from maxo.routing.mixins import message
 from maxo.types import (
     Attachments,
@@ -179,8 +180,9 @@ def _create_retort(*, defaults: BotDefaults | None = None) -> Retort:
         recipe=[
             TAG_PROVIDERS,
             dumper(
-                for_marker(QueryMarker, P[None]),
-                lambda _: "null",
+                is_subclass(MaxoMethod),
+                _omit_none_query_values,
+                chain=Chain.FIRST,
             ),
             dumper(
                 for_marker(QueryMarker, P[bool]),
@@ -240,3 +242,20 @@ def create_retort_with_bot(
         retort = warming_up_retort(retort, warming_up=WarmingUpType.METHOD)
 
     return retort
+
+
+def _omit_none_query_values(method: MaxoMethod[object]) -> MaxoMethod[object]:
+    replacements = {
+        field.name: Omitted()
+        for field in dataclasses.fields(method)
+        if any(
+            isinstance(argument, QueryMarker)
+            for argument in typing.get_args(field.type)
+        )
+        and getattr(method, field.name) is None
+    }
+
+    if not replacements:
+        return method
+
+    return dataclasses.replace(method, **replacements)

--- a/tests/maxo/test_serialization.py
+++ b/tests/maxo/test_serialization.py
@@ -2,7 +2,13 @@ import pytest
 from adaptix.load_error import LoadError
 
 from maxo.bot.defaults import BotDefaults
-from maxo.bot.methods import EditMessage, SendMessage
+from maxo.bot.methods import (
+    EditMessage,
+    GetMembers,
+    GetMessages,
+    GetUpdates,
+    SendMessage,
+)
 from maxo.enums import TextFormat
 from maxo.errors import AttributeIsEmptyError
 from maxo.omit import Omittable, Omitted, is_omitted
@@ -61,6 +67,23 @@ def test_bot_default_disable_link_preview(default: Omittable[bool]) -> None:
         assert "disable_link_preview" not in data["query"]
     else:
         assert data["query"]["disable_link_preview"] == default
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        GetUpdates(marker=None),
+        GetUpdates(types=None),
+        GetMessages(message_ids=None),
+        GetMembers(chat_id=1, user_ids=None),
+    ],
+)
+def test_query_none_is_omitted(method: object) -> None:
+    retort = create_retort(warming_up=False)
+
+    data = retort.dump(method)
+
+    assert not data.get("query")
 
 
 def test_retort_from_bot_load_bot() -> None:


### PR DESCRIPTION
# Описание

В ночь с 16 на 17 августа бот апи макс решило не переваривать `null` в квери и лонгполлинг сломался =)

## Тип изменения

<!-- Удалите неактуальные варианты. Актуальные варианты отметье галочкой -->

- [x] Исправление бага (некритическое изменение, которое устраняет проблему)
- [x] Критические изменения (может быть) (исправление или функционал, из-за которого существующая функциональность не будет работать должным образом)

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего кода
- [x] Я добавил тесты, которые доказывают, что моё исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Параметры запросов со значением `None` теперь исключаются из сериализованных URL вместо преобразования в `null`.
  * Обновлено поведение сериализации для методов получения участников, сообщений и обновлений.
* **Тесты**
  * Добавлены проверки корректного формирования пустой строки query-параметров при отсутствии значений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->