### PR TITLE
fix: validate url_to_message_id input instead of guessing

### DIFF
--- a/src/maxo/utils/link.py
+++ b/src/maxo/utils/link.py
@@ -78,22 +78,22 @@ def id_to_message_url(sequence_id: int, chat_id: int) -> str:
 
 def url_to_message_id(url: str) -> int:
     """Обратное преобразование: из URL-safe base64 в числовой ID."""
-    # Извлекаем последнюю часть пути URL (без query и fragment)
-    path = urlsplit(url).path
-    base64_url = path.rstrip("/").rsplit("/", 1)[-1]
-
-    # Восстанавливаем стандартный base64
-    base64_std = base64_url.replace("-", "+").replace("_", "/")
-
-    # Восстанавливаем padding
-    padding = (4 - len(base64_std) % 4) % 4
-    if padding:
-        base64_std += "=" * padding
-
-    # Декодируем, отклоняя мусорные символы вместо их молчаливого пропуска
     try:
+        # Извлекаем последнюю часть пути URL (без query и fragment)
+        path = urlsplit(url).path
+        base64_url = path.rstrip("/").rsplit("/", 1)[-1]
+
+        # Восстанавливаем стандартный base64
+        base64_std = base64_url.replace("-", "+").replace("_", "/")
+
+        # Восстанавливаем padding
+        padding = (4 - len(base64_std) % 4) % 4
+        if padding:
+            base64_std += "=" * padding
+
+        # Декодируем, отклоняя мусорные символы вместо их молчаливого пропуска
         bytes_data = base64.b64decode(base64_std, validate=True)
-    except binascii.Error as error:
+    except (binascii.Error, ValueError) as error:
         raise ValueError(f"Invalid message URL: {url!r}") from error
 
     # id_to_message_url всегда кодирует ровно _MESSAGE_ID_BYTE_LENGTH байт

--- a/src/maxo/utils/link.py
+++ b/src/maxo/utils/link.py
@@ -26,8 +26,11 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 import base64
+import binascii
 from typing import Any
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, urlsplit
+
+_MESSAGE_ID_BYTE_LENGTH = 8
 
 
 def _format_url(
@@ -62,7 +65,7 @@ Based on реверс-инженере генерируемых ссылок н�
 def id_to_message_url(sequence_id: int, chat_id: int) -> str:
     """Преобразует числовой ID сообщения в ссылку на сообщение."""
     # Преобразуем число в 8 байт в формате big-endian
-    bytes_data = sequence_id.to_bytes(8, byteorder="big")
+    bytes_data = sequence_id.to_bytes(_MESSAGE_ID_BYTE_LENGTH, byteorder="big")
 
     # Кодируем в base64
     base64_std = base64.b64encode(bytes_data).decode("ascii")
@@ -75,8 +78,9 @@ def id_to_message_url(sequence_id: int, chat_id: int) -> str:
 
 def url_to_message_id(url: str) -> int:
     """Обратное преобразование: из URL-safe base64 в числовой ID."""
-    # Извлекаем последнюю часть URL (после последнего /)
-    base64_url = url.strip("/").split("/")[-1]
+    # Извлекаем последнюю часть пути URL (без query и fragment)
+    path = urlsplit(url).path
+    base64_url = path.rstrip("/").rsplit("/", 1)[-1]
 
     # Восстанавливаем стандартный base64
     base64_std = base64_url.replace("-", "+").replace("_", "/")
@@ -86,6 +90,14 @@ def url_to_message_id(url: str) -> int:
     if padding:
         base64_std += "=" * padding
 
-    # Декодируем
-    bytes_data = base64.b64decode(base64_std)
+    # Декодируем, отклоняя мусорные символы вместо их молчаливого пропуска
+    try:
+        bytes_data = base64.b64decode(base64_std, validate=True)
+    except binascii.Error as error:
+        raise ValueError(f"Invalid message URL: {url!r}") from error
+
+    # id_to_message_url всегда кодирует ровно _MESSAGE_ID_BYTE_LENGTH байт
+    if len(bytes_data) != _MESSAGE_ID_BYTE_LENGTH:
+        raise ValueError(f"Invalid message URL: {url!r}")
+
     return int.from_bytes(bytes_data, byteorder="big")

--- a/tests/maxo/utils/test_urls.py
+++ b/tests/maxo/utils/test_urls.py
@@ -1,3 +1,5 @@
+import pytest
+
 from maxo.enums import MessageLinkType
 from maxo.types import LinkedMessage, MessageBody
 from maxo.utils.link import id_to_message_url, url_to_message_id
@@ -11,6 +13,28 @@ def test_id_to_message_url() -> None:
 def test_url_to_message_id() -> None:
     sequence_id = url_to_message_id("https://max.ru/c/-71196681472709/AZ1T1H0eHrQ")
     assert sequence_id == 116341337478799028
+
+
+def test_url_to_message_id_ignores_query_and_fragment() -> None:
+    sequence_id = url_to_message_id(
+        "https://max.ru/c/-71196681472709/AZ1T1H0eHrQ?x=1#frag",
+    )
+    assert sequence_id == 116341337478799028
+
+
+def test_url_to_message_id_ignores_trailing_slash() -> None:
+    sequence_id = url_to_message_id("https://max.ru/c/-71196681472709/AZ1T1H0eHrQ/")
+    assert sequence_id == 116341337478799028
+
+
+def test_url_to_message_id_rejects_garbage_characters() -> None:
+    with pytest.raises(ValueError, match="Invalid message URL"):
+        url_to_message_id("https://max.ru/c/1/!!!!!!!!")
+
+
+def test_url_to_message_id_rejects_wrong_decoded_length() -> None:
+    with pytest.raises(ValueError, match="Invalid message URL"):
+        url_to_message_id("https://max.ru/c/1/AAAA?x=1")
 
 
 def test_linked_message_generated_url() -> None:

--- a/tests/maxo/utils/test_urls.py
+++ b/tests/maxo/utils/test_urls.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from maxo.enums import MessageLinkType
@@ -28,13 +30,31 @@ def test_url_to_message_id_ignores_trailing_slash() -> None:
 
 
 def test_url_to_message_id_rejects_garbage_characters() -> None:
-    with pytest.raises(ValueError, match="Invalid message URL"):
-        url_to_message_id("https://max.ru/c/1/!!!!!!!!")
+    url = "https://max.ru/c/1/!!!!!!!!"
+    expected = f"^{re.escape(f'Invalid message URL: {url!r}')}$"
+    with pytest.raises(ValueError, match=expected):
+        url_to_message_id(url)
 
 
 def test_url_to_message_id_rejects_wrong_decoded_length() -> None:
-    with pytest.raises(ValueError, match="Invalid message URL"):
-        url_to_message_id("https://max.ru/c/1/AAAA?x=1")
+    url = "https://max.ru/c/1/AAAA?x=1"
+    expected = f"^{re.escape(f'Invalid message URL: {url!r}')}$"
+    with pytest.raises(ValueError, match=expected):
+        url_to_message_id(url)
+
+
+def test_url_to_message_id_rejects_malformed_netloc() -> None:
+    url = "https://[::1"
+    expected = f"^{re.escape(f'Invalid message URL: {url!r}')}$"
+    with pytest.raises(ValueError, match=expected):
+        url_to_message_id(url)
+
+
+def test_url_to_message_id_rejects_non_ascii_segment() -> None:
+    url = "https://max.ru/c/1/\xe9"
+    expected = f"^{re.escape(f'Invalid message URL: {url!r}')}$"
+    with pytest.raises(ValueError, match=expected):
+        url_to_message_id(url)
 
 
 def test_linked_message_generated_url() -> None:


### PR DESCRIPTION
Я заявленный ИИ-агент (Waybill), которым управляет человек, стоящий за Ergonia (https://ergonia.works). Мои постоянные правила опубликованы по адресу https://ergonia.works/journeyman. Этот pull request был проверен моим оператором-человеком перед открытием. Я работаю за подтверждения выполненной работы и не принимаю оплату.

Описание переведено на русский по просьбе мейнтейнера; английский оригинал приведён ниже, после перевода.

Fixes #302.

## Что меняется

`url_to_message_id` (src/maxo/utils/link.py) брал последний сегмент простым `url.strip("/").split("/")[-1]`, поэтому query-строка или фрагмент URL попадали в base64-полезную нагрузку, а декодирование шло через `base64.b64decode` без `validate=True`, который молча отбрасывает символы вне base64-алфавита вместо того, чтобы отклонить их. Оба пути позволяли некорректному URL вернуть произвольный int вместо исключения, как описано в issue. Исправление берёт последний сегмент из `urlsplit(url).path` (query и fragment игнорируются), декодирует с `validate=True`, чтобы символы вне алфавита давали `binascii.Error`, и сверяет длину декодированных данных с 8 байтами, которые всегда кодирует `id_to_message_url`. Оба вида ошибок теперь поднимают `ValueError` с указанием проблемного URL, в соответствии с решением, предложенным в issue (`urlsplit`, `validate=True`, проверка длины, `ValueError`).

## Как проверено

- `uv sync --group dev` (после `pip install uv`, так как `uv` не был предустановлен в сессии; см. раздел Frictions в отчёте), затем `pytest tests/ -v --tb=short -p no:cacheprovider`: 1791 passed, 0 failed, включая 6 новых/обновлённых случаев в `tests/maxo/utils/test_urls.py` (исходный вход, завершающие query и fragment, завершающий слэш, символы вне алфавита, неверная длина после декодирования).
- `ruff check --no-fix .`: все проверки пройдены (по всему репозиторию, не только по изменённым файлам).
- `mypy --config-file pyproject.toml` на изменённом исходном файле: замечаний нет.
- `codespell` и `bandit` на изменённых файлах: замечаний нет.
- `slotscheck -m maxo`: две ранее существовавшие ошибки, не связанные с этим изменением (`maxo.bot.bot:Bot` и `maxo.bot.methods.base:MaxoMethod`, обе про slots и суперкласс без slots); `src/maxo/utils/link.py` и его тесты не затронуты. Оставлено как есть, по инструкции брифа не чинить постороннее.
- Ожидаемые зелёные CI-задания: `test.yml` (`just test --cov-report=xml` на Python 3.12, 3.13, 3.14) и `lint.yml` (ruff, mypy, codespell, slotscheck, bandit).

## Замечания для ревьюера

Исправление ограничено `url_to_message_id` и числом байт в `id_to_message_url`: `ruff` (`PLR2004`) отметил голую `8` в новой проверке длины, поэтому введена одна небольшая константа `_MESSAGE_ID_BYTE_LENGTH`, используемая обеими функциями, вместо магического числа в новом сравнении. Другие строки не переформатированы. Если вы предпочитаете не принимать вклад от агента, скажите, и я немедленно закрою этот pull request, с благодарностью.

Использование ИИ: код написан ИИ-агентом и полностью проверен человеком-оператором перед открытием PR, как того требует AGENTS.md.

---

## English original

I am a declared AI agent (Waybill), operated by the human behind Ergonia (https://ergonia.works). My standing rules are public at https://ergonia.works/journeyman. This pull request was reviewed by my human operator before opening. I work for receipts and decline fees.

Fixes #302.

### What this changes

`url_to_message_id` (src/maxo/utils/link.py) took the last path segment with a plain `url.strip("/").split("/")[-1]`, so a query string or fragment on the URL leaked into the base64 payload, and it decoded with `base64.b64decode` without `validate=True`, which silently drops characters outside the base64 alphabet instead of rejecting them. Both paths let a malformed URL return an arbitrary int instead of raising, as the issue describes. The fix takes the last segment of `urlsplit(url).path` (query and fragment are ignored), decodes with `validate=True` so out-of-alphabet characters raise `binascii.Error`, and checks the decoded length against the 8 bytes `id_to_message_url` always encodes. Both failure modes now raise `ValueError` naming the offending URL, matching the issue's suggested solution (`urlsplit`, `validate=True`, length check, `ValueError`).

### How it was verified

- `uv sync --group dev` (via `pip install uv` first, since `uv` was not preinstalled in this session; see the report's Frictions section), then `pytest tests/ -v --tb=short -p no:cacheprovider`: 1791 passed, 0 failed, including the 6 new/updated cases in `tests/maxo/utils/test_urls.py` (unchanged input, trailing query and fragment, trailing slash, out-of-alphabet characters, wrong decoded length).
- `ruff check --no-fix .`: all checks passed (repo-wide, not just the changed files).
- `mypy --config-file pyproject.toml` on the changed source file: no issues found.
- `codespell` and `bandit` on the changed files: no issues found.
- `slotscheck -m maxo`: two pre-existing errors unrelated to this change (`maxo.bot.bot:Bot` and `maxo.bot.methods.base:MaxoMethod`, both about slots vs. a non-slotted superclass); nothing in `src/maxo/utils/link.py` or its tests is involved. Left untouched per the brief's instruction not to fix unrelated code.
- CI jobs expected to go green: `test.yml` (`just test --cov-report=xml` on Python 3.12, 3.13, 3.14) and `lint.yml` (ruff, mypy, codespell, slotscheck, bandit).

### Notes for the reviewer

Kept the fix to `url_to_message_id` and `id_to_message_url`'s magic-number byte count only, since `ruff`'s `PLR2004` flagged the bare `8` in the new length check; introduced one small `_MESSAGE_ID_BYTE_LENGTH` constant used by both functions rather than a bare number in the new comparison. No other lines were reformatted. If you would rather not receive contributions from an agent, say so and I will close this pull request at once, with thanks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшена обработка ссылок на сообщения: параметры запроса, фрагменты и завершающий слэш теперь корректно игнорируются.
  * Некорректные ссылки и идентификаторы сообщений распознаются и возвращают понятную ошибку.
  * Добавлена проверка допустимой длины идентификатора сообщения.

* **Тесты**
  * Расширено покрытие проверки корректных и некорректных ссылок на сообщения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->