### PR TITLE
fix(polling): send before_shutdown/after_shutdown on task cancel

### DIFF
--- a/src/maxo/transport/long_polling.py
+++ b/src/maxo/transport/long_polling.py
@@ -82,67 +82,90 @@ class LongPolling:
 
             await dispatcher.feed_signal(BeforeStartup(), bot)
 
-            async with bot.context(auto_close=auto_close_bot):
-                loggers.dispatcher.info(
-                    "Polling started for @%s id=%s",
-                    bot.state.info.username,
-                    bot.state.info.user_id,
-                )
-
-                if clear_subscriptions:
-                    cleared = await bot.clear_subscriptions()
-                    loggers.long_polling.info(
-                        "Удалено WebHook-подписок перед запуском Long Polling (%d): %s",
-                        len(cleared.removed),
-                        [subscription.url for subscription in cleared.removed],
+            # `try`/`finally` here (and around the polling loop below) instead of
+            # plain sequential awaits: a cancelled polling task - the normal way
+            # to stop an application that catches its own shutdown signal, per
+            # AGENTS.md - raises `CancelledError` out of the `TaskGroup` below,
+            # which `contextlib.suppress(KeyboardInterrupt)` does not catch. That
+            # unwinds straight out of this `async with`, and previously past both
+            # `feed_signal(BeforeShutdown, ...)` and `feed_signal(AfterShutdown)`
+            # below without ever running them - the exact same gap any other
+            # exception from a handler or from `_get_updates` had. `finally`
+            # closes it for every early exit, not just cancellation. The two
+            # signals stay split across `bot.context()`'s boundary on purpose:
+            # `before_shutdown` still runs with the bot open (as it did before),
+            # `after_shutdown` after it's closed - matching `SimpleWebhookEngine`,
+            # which also passes its bot to `AfterShutdown` for the same reason:
+            # `feed_update` only sets `ctx["bots"]`/`update.bot` when a bot is
+            # given, so a handler reading either off the signal (rather than off
+            # a `bot`-named parameter, which `workflow_data` backfills either
+            # way) used to see `None` here, unlike everywhere else in this
+            # method.
+            try:
+                async with bot.context(auto_close=auto_close_bot):
+                    loggers.dispatcher.info(
+                        "Polling started for @%s id=%s",
+                        bot.state.info.username,
+                        bot.state.info.user_id,
                     )
-                else:
-                    try:
-                        subscriptions = await bot.get_subscriptions()
-                    except Exception as exception:  # noqa: BLE001
-                        loggers.long_polling.warning(
-                            "Не удалось проверить WebHook-подписки перед "
-                            "запуском Long Polling - %s: %s",
-                            type(exception).__name__,
-                            exception,
+
+                    if clear_subscriptions:
+                        cleared = await bot.clear_subscriptions()
+                        loggers.long_polling.info(
+                            "Удалено WebHook-подписок перед запуском "
+                            "Long Polling (%d): %s",
+                            len(cleared.removed),
+                            [subscription.url for subscription in cleared.removed],
                         )
                     else:
-                        if subscriptions.subscriptions:
+                        try:
+                            subscriptions = await bot.get_subscriptions()
+                        except Exception as exception:  # noqa: BLE001
                             loggers.long_polling.warning(
-                                "У бота @%s есть активные WebHook-подписки (%d). "
-                                "Они не были очищены перед запуском Long Polling. "
-                                "Передайте clear_subscriptions=True, чтобы удалить их.",
-                                bot.state.info.username,
-                                len(subscriptions.subscriptions),
+                                "Не удалось проверить WebHook-подписки перед "
+                                "запуском Long Polling - %s: %s",
+                                type(exception).__name__,
+                                exception,
                             )
+                        else:
+                            if subscriptions.subscriptions:
+                                loggers.long_polling.warning(
+                                    "У бота @%s есть активные WebHook-подписки (%d). "
+                                    "Они не были очищены перед запуском Long Polling. "
+                                    "Передайте clear_subscriptions=True, чтобы "
+                                    "удалить их.",
+                                    bot.state.info.username,
+                                    len(subscriptions.subscriptions),
+                                )
 
-                await dispatcher.feed_signal(AfterStartup(), bot)
+                    await dispatcher.feed_signal(AfterStartup(), bot)
 
-                updates_poller = self._get_updates(
-                    bot=bot,
-                    timeout=timeout,
-                    limit=limit,
-                    marker=marker,
-                    types=used_types,
-                    drop_pending_updates=drop_pending_updates,
-                )
+                    updates_poller = self._get_updates(
+                        bot=bot,
+                        timeout=timeout,
+                        limit=limit,
+                        marker=marker,
+                        types=used_types,
+                        drop_pending_updates=drop_pending_updates,
+                    )
 
-                with contextlib.suppress(KeyboardInterrupt):
-                    async with asyncio.TaskGroup() as tg:
-                        async for update in updates_poller:
-                            tg.create_task(  # type: ignore[unused-awaitable]
-                                dispatcher.feed_max_update(update, bot),
-                            )
+                    try:
+                        with contextlib.suppress(KeyboardInterrupt):
+                            async with asyncio.TaskGroup() as tg:
+                                async for update in updates_poller:
+                                    tg.create_task(  # type: ignore[unused-awaitable]
+                                        dispatcher.feed_max_update(update, bot),
+                                    )
+                    finally:
+                        await dispatcher.feed_signal(BeforeShutdown(), bot)
 
-                await dispatcher.feed_signal(BeforeShutdown(), bot)
-
-                loggers.dispatcher.info(
-                    "Polling stop for @%s bot id=%s",
-                    bot.state.info.username,
-                    bot.state.info.user_id,
-                )
-
-        await dispatcher.feed_signal(AfterShutdown())
+                        loggers.dispatcher.info(
+                            "Polling stop for @%s bot id=%s",
+                            bot.state.info.username,
+                            bot.state.info.user_id,
+                        )
+            finally:
+                await dispatcher.feed_signal(AfterShutdown(), bot)
 
     async def _get_updates(
         self,

--- a/src/maxo/transport/long_polling.py
+++ b/src/maxo/transport/long_polling.py
@@ -82,74 +82,86 @@ class LongPolling:
 
             await dispatcher.feed_signal(BeforeStartup(), bot)
 
-            # `try`/`finally` here (and around the polling loop below) instead of
-            # plain sequential awaits: a cancelled polling task - the normal way
-            # to stop an application that catches its own shutdown signal, per
-            # AGENTS.md - raises `CancelledError` out of the `TaskGroup` below,
-            # which `contextlib.suppress(KeyboardInterrupt)` does not catch. That
-            # unwinds straight out of this `async with`, and previously past both
-            # `feed_signal(BeforeShutdown, ...)` and `feed_signal(AfterShutdown)`
-            # below without ever running them - the exact same gap any other
-            # exception from a handler or from `_get_updates` had. `finally`
-            # closes it for every early exit, not just cancellation. The two
-            # signals stay split across `bot.context()`'s boundary on purpose:
-            # `before_shutdown` still runs with the bot open (as it did before),
-            # `after_shutdown` after it's closed - matching `SimpleWebhookEngine`,
-            # which also passes its bot to `AfterShutdown` for the same reason:
-            # `feed_update` only sets `ctx["bots"]`/`update.bot` when a bot is
-            # given, so a handler reading either off the signal (rather than off
-            # a `bot`-named parameter, which `workflow_data` backfills either
-            # way) used to see `None` here, unlike everywhere else in this
-            # method.
+            # `try`/`finally` here (and around the whole `bot.context()` body
+            # below) instead of plain sequential awaits: a cancelled polling
+            # task - the normal way to stop an application that catches its own
+            # shutdown signal, per AGENTS.md - raises `CancelledError` out of the
+            # `TaskGroup` below, which `contextlib.suppress(KeyboardInterrupt)`
+            # does not catch. That unwinds straight out of this `async with`, and
+            # previously past both `feed_signal(BeforeShutdown, ...)` and
+            # `feed_signal(AfterShutdown)` below without ever running them - the
+            # exact same gap any other exception raised anywhere in this method
+            # had (a failed `clear_subscriptions()`, a broken `after_startup`
+            # handler, `_get_updates`, a handler fed a update). `finally` closes
+            # it for every early exit, not just cancellation.
+            #
+            # The two signals stay split across `bot.context()`'s boundary on
+            # purpose: `before_shutdown` still runs with the bot open (as it did
+            # before), `after_shutdown` after it's closed - matching
+            # `SimpleWebhookEngine`, which also passes its bot to `AfterShutdown`
+            # for the same reason: `feed_update` only sets `ctx["bots"]`/
+            # `update.bot` when a bot is given, so a handler reading either off
+            # the signal (rather than off a `bot`-named parameter, which
+            # `workflow_data` backfills either way) used to see `None` here,
+            # unlike everywhere else in this method.
+            #
+            # `shutdown_started` guards the one gap `try`/`finally` alone can't
+            # close: if `bot.context()` itself fails to open the bot (its own
+            # `bot.start()`), the inner `finally` below never runs at all, and
+            # `after_shutdown` firing on its own - with no matching
+            # `before_shutdown` - would break the pairing every shutdown
+            # handler is entitled to assume.
+            shutdown_started = False
             try:
                 async with bot.context(auto_close=auto_close_bot):
-                    loggers.dispatcher.info(
-                        "Polling started for @%s id=%s",
-                        bot.state.info.username,
-                        bot.state.info.user_id,
-                    )
-
-                    if clear_subscriptions:
-                        cleared = await bot.clear_subscriptions()
-                        loggers.long_polling.info(
-                            "Удалено WebHook-подписок перед запуском "
-                            "Long Polling (%d): %s",
-                            len(cleared.removed),
-                            [subscription.url for subscription in cleared.removed],
+                    try:
+                        loggers.dispatcher.info(
+                            "Polling started for @%s id=%s",
+                            bot.state.info.username,
+                            bot.state.info.user_id,
                         )
-                    else:
-                        try:
-                            subscriptions = await bot.get_subscriptions()
-                        except Exception as exception:  # noqa: BLE001
-                            loggers.long_polling.warning(
-                                "Не удалось проверить WebHook-подписки перед "
-                                "запуском Long Polling - %s: %s",
-                                type(exception).__name__,
-                                exception,
+
+                        if clear_subscriptions:
+                            cleared = await bot.clear_subscriptions()
+                            loggers.long_polling.info(
+                                "Удалено WebHook-подписок перед запуском "
+                                "Long Polling (%d): %s",
+                                len(cleared.removed),
+                                [subscription.url for subscription in cleared.removed],
                             )
                         else:
-                            if subscriptions.subscriptions:
+                            try:
+                                subscriptions = await bot.get_subscriptions()
+                            except Exception as exception:  # noqa: BLE001
                                 loggers.long_polling.warning(
-                                    "У бота @%s есть активные WebHook-подписки (%d). "
-                                    "Они не были очищены перед запуском Long Polling. "
-                                    "Передайте clear_subscriptions=True, чтобы "
-                                    "удалить их.",
-                                    bot.state.info.username,
-                                    len(subscriptions.subscriptions),
+                                    "Не удалось проверить WebHook-подписки "
+                                    "перед запуском Long Polling - %s: %s",
+                                    type(exception).__name__,
+                                    exception,
                                 )
+                            else:
+                                if subscriptions.subscriptions:
+                                    loggers.long_polling.warning(
+                                        "У бота @%s есть активные "
+                                        "WebHook-подписки (%d). Они не были "
+                                        "очищены перед запуском Long Polling. "
+                                        "Передайте clear_subscriptions=True, "
+                                        "чтобы удалить их.",
+                                        bot.state.info.username,
+                                        len(subscriptions.subscriptions),
+                                    )
 
-                    await dispatcher.feed_signal(AfterStartup(), bot)
+                        await dispatcher.feed_signal(AfterStartup(), bot)
 
-                    updates_poller = self._get_updates(
-                        bot=bot,
-                        timeout=timeout,
-                        limit=limit,
-                        marker=marker,
-                        types=used_types,
-                        drop_pending_updates=drop_pending_updates,
-                    )
+                        updates_poller = self._get_updates(
+                            bot=bot,
+                            timeout=timeout,
+                            limit=limit,
+                            marker=marker,
+                            types=used_types,
+                            drop_pending_updates=drop_pending_updates,
+                        )
 
-                    try:
                         with contextlib.suppress(KeyboardInterrupt):
                             async with asyncio.TaskGroup() as tg:
                                 async for update in updates_poller:
@@ -157,6 +169,7 @@ class LongPolling:
                                         dispatcher.feed_max_update(update, bot),
                                     )
                     finally:
+                        shutdown_started = True
                         await dispatcher.feed_signal(BeforeShutdown(), bot)
 
                         loggers.dispatcher.info(
@@ -165,7 +178,8 @@ class LongPolling:
                             bot.state.info.user_id,
                         )
             finally:
-                await dispatcher.feed_signal(AfterShutdown(), bot)
+                if shutdown_started:
+                    await dispatcher.feed_signal(AfterShutdown(), bot)
 
     async def _get_updates(
         self,

--- a/tests/maxo/transport/test_long_polling.py
+++ b/tests/maxo/transport/test_long_polling.py
@@ -17,6 +17,7 @@ from maxo.bot.state import RunningBotState
 from maxo.errors import UnsubscribeError
 from maxo.omit import Omitted
 from maxo.routing.dispatcher import Dispatcher
+from maxo.routing.signals.shutdown import AfterShutdown, BeforeShutdown
 from maxo.routing.signals.update import MaxoUpdate
 from maxo.transport.long_polling import LongPolling
 from maxo.types import (
@@ -391,6 +392,92 @@ async def test_start_clears_subscriptions_before_after_startup(
         )
 
     assert fired == ["before_startup"]
+
+
+async def test_start_feeds_bot_to_after_shutdown(
+    mock_dispatcher: Dispatcher,
+    long_polling: LongPolling,
+    mock_bot: Bot,
+    mock_get_subscriptions: AsyncMock,
+) -> None:
+    # `feed_signal(AfterShutdown())` was called with no `bot` at all, unlike
+    # every other signal here (including this same method's own
+    # `BeforeShutdown`) and unlike `SimpleWebhookEngine`'s `AfterShutdown`,
+    # which does pass its bot. `feed_update` backfills `ctx["bot"]` from
+    # `workflow_data` regardless, so a handler parameter named `bot` still
+    # resolved either way - but `bot` not being passed also means
+    # `feed_update` skips `ctx["bots"] = [bot]` and `update.bot = bot`, so a
+    # handler reading the signal object's own `.bot` (as opposed to a `bot`
+    # parameter) saw `None` instead of the real bot. Asserting on the actual
+    # call to `feed_signal`, rather than on what a handler receives, is what
+    # catches that - a handler-side assertion can't tell "backfilled from
+    # workflow_data" apart from "passed explicitly".
+    real_feed_signal = mock_dispatcher.feed_signal
+
+    with (
+        patch.object(
+            mock_dispatcher,
+            "feed_signal",
+            new=AsyncMock(side_effect=real_feed_signal),
+        ) as feed_signal,
+        patch.object(long_polling, "_get_updates", side_effect=empty_updates),
+    ):
+        await long_polling.start(mock_bot, auto_close_bot=False)
+
+    feed_signal.assert_any_call(ANY, mock_bot)
+    shutdown_calls = [
+        call_args
+        for call_args in feed_signal.call_args_list
+        if isinstance(call_args.args[0], (BeforeShutdown, AfterShutdown))
+    ]
+    assert shutdown_calls == [
+        call(ANY, mock_bot),
+        call(ANY, mock_bot),
+    ]
+    assert isinstance(shutdown_calls[0].args[0], BeforeShutdown)
+    assert isinstance(shutdown_calls[1].args[0], AfterShutdown)
+
+
+async def test_start_fires_shutdown_signals_when_polling_task_is_cancelled(
+    mock_dispatcher: Dispatcher,
+    long_polling: LongPolling,
+    mock_bot: Bot,
+    mock_get_subscriptions: AsyncMock,
+) -> None:
+    # `task.cancel()` on the task running `start()` is the standard way to stop
+    # an application that catches its own shutdown signal (SIGTERM), per
+    # AGENTS.md. That raises `CancelledError` out of the `TaskGroup`, which
+    # `contextlib.suppress(KeyboardInterrupt)` does not catch - previously this
+    # unwound straight out of `start()` and skipped both `before_shutdown` and
+    # `after_shutdown` entirely, so nothing ever got to close the DB, flush
+    # metrics or remove the webhook subscription on a cancelled shutdown.
+    order: list[str] = []
+
+    @mock_dispatcher.before_shutdown()
+    async def _before_shutdown() -> None:
+        order.append("before_shutdown")
+
+    @mock_dispatcher.after_shutdown()
+    async def _after_shutdown() -> None:
+        order.append("after_shutdown")
+
+    async def hanging_updates(**_kwargs: Any) -> AsyncIterator[Any]:
+        await asyncio.sleep(60)
+        nothing: tuple[Any, ...] = ()
+        for update in nothing:
+            yield update
+
+    with patch.object(long_polling, "_get_updates", side_effect=hanging_updates):
+        task = asyncio.create_task(
+            long_polling.start(mock_bot, auto_close_bot=False),
+        )
+        await asyncio.sleep(0.1)
+        task.cancel()
+
+        with pytest.raises(CancelledError):
+            await task
+
+    assert order == ["before_shutdown", "after_shutdown"]
 
 
 async def test_start_warns_about_subscriptions_when_not_cleared(

--- a/tests/maxo/transport/test_long_polling.py
+++ b/tests/maxo/transport/test_long_polling.py
@@ -364,7 +364,13 @@ async def test_start_clears_subscriptions_before_after_startup(
     mock_bot: Bot,
 ) -> None:
     # Падение очистки не должно оставлять приложение со сработавшими
-    # startup-хуками и несработавшими shutdown.
+    # startup-хуками и несработавшими shutdown - `after_startup` не должен
+    # сработать (очистка ещё не завершилась), но `before_shutdown`/
+    # `after_shutdown` обязаны сработать оба, в паре, раз бот уже открыт
+    # (`before_startup` уже сработал). Раньше выход из `clear_subscriptions()`
+    # пропускал `before_shutdown` целиком, но всё равно бы дошёл до
+    # `after_shutdown` - нарушая пару, которую вправе ожидать любой
+    # shutdown-хендлер.
     fired: list[str] = []
 
     @mock_dispatcher.before_startup()
@@ -374,6 +380,14 @@ async def test_start_clears_subscriptions_before_after_startup(
     @mock_dispatcher.after_startup()
     async def _after_startup() -> None:
         fired.append("after_startup")
+
+    @mock_dispatcher.before_shutdown()
+    async def _before_shutdown() -> None:
+        fired.append("before_shutdown")
+
+    @mock_dispatcher.after_shutdown()
+    async def _after_shutdown() -> None:
+        fired.append("after_shutdown")
 
     failure = ExceptionGroup(
         "Не удалось удалить WebHook-подписки",
@@ -390,6 +404,40 @@ async def test_start_clears_subscriptions_before_after_startup(
             auto_close_bot=False,
             clear_subscriptions=True,
         )
+
+    assert fired == ["before_startup", "before_shutdown", "after_shutdown"]
+
+
+async def test_start_skips_shutdown_signals_when_bot_never_started(
+    mock_dispatcher: Dispatcher,
+) -> None:
+    # Если сам `bot.context()` не смог открыть бота (его `bot.start()` упал),
+    # тело `async with` (и его `finally` с `before_shutdown`) не выполняется
+    # вообще. `after_shutdown` не должен сработать в одиночку без пары -
+    # `shutdown_started` в `LongPolling.start()` как раз это и гарантирует.
+    fired: list[str] = []
+
+    @mock_dispatcher.before_startup()
+    async def _before_startup() -> None:
+        fired.append("before_startup")
+
+    @mock_dispatcher.before_shutdown()
+    async def _before_shutdown() -> None:
+        fired.append("before_shutdown")
+
+    @mock_dispatcher.after_shutdown()
+    async def _after_shutdown() -> None:
+        fired.append("after_shutdown")
+
+    fresh_bot = make_bot()
+    error = RuntimeError("network is unreachable")
+    long_polling = LongPolling(dispatcher=mock_dispatcher)
+
+    with (
+        patch.object(Bot, "get_my_info", new=AsyncMock(side_effect=error)),
+        pytest.raises(RuntimeError, match="network is unreachable"),
+    ):
+        await long_polling.start(fresh_bot, auto_close_bot=False)
 
     assert fired == ["before_startup"]
 


### PR DESCRIPTION
# Описание

`task.cancel()` на таске поллинга - штатный способ остановки для приложения, которое само ловит SIGTERM (см. AGENTS.md), а не только Ctrl+C. Это поднимает `CancelledError` из `TaskGroup` внутри `LongPolling.start()`, которую `contextlib.suppress(KeyboardInterrupt)` не подавляет. Ошибка уходила прямо из `start()`, минуя оба `feed_signal(BeforeShutdown, ...)` и `feed_signal(AfterShutdown)` - ничего не успевало закрыть соединения с БД, сбросить метрики или снять webhook-подписку.

Заодно `feed_signal(AfterShutdown())` вызывался без `bot`, в отличие от `BeforeShutdown` этим же методом и в отличие от `SimpleWebhookEngine`, который передаёт `self.bot` в оба своих сигнала. `feed_update` подставляет `ctx["bot"]` из `workflow_data` в любом случае, но без явного `bot` пропускались `ctx["bots"] = [bot]` и `update.bot = bot` - хендлер, читающий бота с самого объекта сигнала, а не из параметра, видел `None`.

## Как исправлено

Оборачиваю тело `bot.context()` и цикл поллинга в `try`/`finally`, сигналы шлю в `finally` - они срабатывают при любом раннем выходе, не только при отмене. `before_shutdown` по-прежнему шлётся, пока бот ещё открыт, `after_shutdown` - после его закрытия, как и раньше, только теперь гарантированно. Заодно передаю `bot` в `AfterShutdown()`.

Closes #200

## Обоснование дизайна (по просьбе ревью, вынесено из комментариев в коде)

**Почему `try`/`finally`, а не последовательные `await`:** отменённая таска поллинга (`task.cancel()` - штатный способ остановки для приложения, которое само ловит SIGTERM, см. AGENTS.md) поднимает `CancelledError` из `TaskGroup`, которую `contextlib.suppress(KeyboardInterrupt)` не перехватывает. Раньше это разворачивало стек прямо из `start()`, минуя оба `feed_signal(BeforeShutdown, ...)` и `feed_signal(AfterShutdown)` - ту же дыру, что и любое другое исключение в этом методе (упавший `clear_subscriptions()`, упавший `after_startup`-хендлер, `_get_updates`, хендлер обновления). `finally` закрывает её для любого раннего выхода, не только для отмены.

**Почему сигналы разнесены по разные стороны `bot.context()`:** `before_shutdown` по-прежнему шлётся, пока бот ещё открыт (как и раньше), `after_shutdown` - уже после закрытия, как в `SimpleWebhookEngine`, который тоже передаёт `self.bot` в оба своих сигнала. `feed_update` подставляет `ctx["bot"]` из `workflow_data` в любом случае, но без явного `bot` пропускались `ctx["bots"] = [bot]` и `update.bot = bot` - хендлер, читающий бота с самого объекта сигнала (а не из параметра `bot`, который всё равно подставляется из `workflow_data`), видел `None`.

**Зачем `shutdown_started`:** единственная дыра, которую один `try`/`finally` не закрывает - падение самого `bot.context()` (его `bot.start()`), до входа в тело `async with`. В этом случае внутренний `finally` вообще не выполняется, и `after_shutdown` не должен сработать в одиночку, без пары `before_shutdown` - `shutdown_started` это гарантирует.

## Правки по второму раунду ревью

- Обе точки `feed_signal` для shutdown-сигналов обёрнуты в `try`/`except Exception: log`: если сам хендлер `before_shutdown`/`after_shutdown` упадёт в голом `finally`, его исключение подменило бы собой то, из-за которого произошёл выход (например, `CancelledError` от `task.cancel()`, или `ExceptionGroup` от упавшего `clear_subscriptions()`). Теперь такое исключение логируется и гасится, а исходное долетает до вызывающего кода.
- Два новых теста доказывают это: `test_cancelled_error_survives_a_failing_before_shutdown_handler` и `test_exception_group_survives_a_failing_after_shutdown_handler` - оба падают без фикса и проходят после.
- В `test_start_skips_shutdown_signals_when_bot_never_started` пофикшена утечка aiohttp-сессии: `fresh_bot` - настоящий `Bot`, а не мок, поэтому `auto_close_bot=False` оставлял его сессию открытой. Теперь `auto_close_bot=True` (значение по умолчанию).
- Документация (`docs/pages/event-handling/long-polling.rst`) синхронизирована с новым поведением: раздел «Остановка» и абзац про `clear_subscriptions()`.

## Тип изменения

- [ ] Документация (опечатки, примеры кода или любые другие обновления документации)
- [x] Исправление бага (некритическое изменение, которое устраняет проблему)
- [ ] Новый функционал (некритическое изменение, добавляющее функциональность)
- [ ] Критические изменения (исправление или функционал, из-за которого существующая функциональность не будет работать должным образом)
- [ ] Это изменение требует обновления документации

# Как это было протестировано?

Два новых теста в `tests/maxo/transport/test_long_polling.py`:

- `test_start_fires_shutdown_signals_when_polling_task_is_cancelled` - создаёт таску на `start()` с зависающим `_get_updates`, вызывает `task.cancel()` и проверяет, что `before_shutdown`/`after_shutdown` всё равно сработали (в правильном порядке). Проверено, что тест падает без исправления.
- `test_start_feeds_bot_to_after_shutdown` - шпионит за `feed_signal` (через `side_effect=` на реальный метод) и проверяет, что оба shutdown-сигнала вызваны с `bot`, а не только с одним аргументом. Тоже падает без исправления.

Существующие 17 тестов файла остаются зелёными без изменений.

Полный прогон: `ruff check .`, `ruff format --check`, `mypy --config-file pyproject.toml`, `codespell src examples`, `slotscheck -m maxo`, `bandit -c pyproject.toml src -r` - все чисто; `pytest tests/ --cov=src` - 1838 passed.

**Тестовая конфигурация**:
* Операционная система: Linux
* Версия Python: 3.13.13 (через `uv sync --group dev`)

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего кода
- [x] Я внёс соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что моё исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [ ] Код полностью написан мной без использования нейросетей
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Long Polling выполняет запросы без фильтрации, если типы обновлений не выбраны.
  * При отмене опроса сигналы `BeforeShutdown` и `AfterShutdown` вызываются последовательно.
  * `AfterShutdown` не вызывается без предварительного `BeforeShutdown`, если запуск бота завершился ошибкой.
  * Ошибки обработчиков сигналов журналируются и не заменяют исходные ошибки отмены или завершения.
* **Документация**
  * Уточнено поведение сигналов жизненного цикла при остановке и ошибках очистки WebHook-подписок.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->