### PR TITLE
fix: выполнять хендлеры-классы с `async def __call__`

### DIFF
--- a/src/maxo/dialogs/widgets/filter_object.py
+++ b/src/maxo/dialogs/widgets/filter_object.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 from maxo.dialogs.integrations.magic_filter import DialogMagic
 from maxo.routing.interfaces import Filter
+from maxo.routing.utils.is_async_callable import is_async_callable
 
 CallbackType = Callable[..., Any]
 CallbackVariant = CallbackType | DialogMagic
@@ -26,9 +27,7 @@ class CallableObject:
 
     def __post_init__(self) -> None:
         callback = inspect.unwrap(self._callable())
-        self.awaitable = inspect.isawaitable(callback) or inspect.iscoroutinefunction(
-            callback,
-        )
+        self.awaitable = is_async_callable(callback)
         spec = inspect.getfullargspec(callback)
         self.params = {*spec.args, *spec.kwonlyargs}
         self.varkw = spec.varkw is not None

--- a/src/maxo/routing/handlers/signal.py
+++ b/src/maxo/routing/handlers/signal.py
@@ -10,6 +10,7 @@ from maxo.routing.flags import resolve_handler_flags
 from maxo.routing.interfaces.filter import Filter
 from maxo.routing.interfaces.handler import Handler
 from maxo.routing.signals.base import BaseSignal
+from maxo.routing.utils.is_async_callable import is_async_callable
 
 _SignalT = TypeVar("_SignalT", bound=BaseSignal)
 _ReturnT_co = TypeVar("_ReturnT_co", covariant=True)
@@ -43,10 +44,8 @@ class SignalHandler(Handler[_SignalT, _ReturnT_co], Generic[_SignalT, _ReturnT_c
         self._filter = combine_filters(*filters)
         self._handler_fn = handler_fn
         self._flags = resolve_handler_flags(handler_fn, filters, flags)
-        self._awaitable = inspect.isawaitable(
-            handler_fn,
-        ) or inspect.iscoroutinefunction(handler_fn)
-        spec = inspect.getfullargspec(handler_fn)
+        self._awaitable = is_async_callable(handler_fn)
+        spec = inspect.getfullargspec(inspect.unwrap(handler_fn))
         self._params = {*spec.args, *spec.kwonlyargs}
         self._varkw = spec.varkw is not None
 

--- a/src/maxo/routing/handlers/update.py
+++ b/src/maxo/routing/handlers/update.py
@@ -9,6 +9,7 @@ from maxo.routing.filters.logic import combine_filters
 from maxo.routing.flags import resolve_handler_flags
 from maxo.routing.interfaces.filter import Filter
 from maxo.routing.interfaces.handler import Handler
+from maxo.routing.utils.is_async_callable import is_async_callable
 from maxo.types.base import BaseUpdate
 
 _UpdateT = TypeVar("_UpdateT", bound=BaseUpdate)
@@ -48,10 +49,8 @@ class UpdateHandler(
         self._filter = combine_filters(*filters)
         self._handler_fn = handler_fn
         self._flags = resolve_handler_flags(handler_fn, filters, flags)
-        self._awaitable = inspect.isawaitable(
-            handler_fn,
-        ) or inspect.iscoroutinefunction(handler_fn)
-        spec = inspect.getfullargspec(handler_fn)
+        self._awaitable = is_async_callable(handler_fn)
+        spec = inspect.getfullargspec(inspect.unwrap(handler_fn))
         self._params = {*spec.args, *spec.kwonlyargs}
         self._varkw = spec.varkw is not None
 

--- a/src/maxo/routing/utils/__init__.py
+++ b/src/maxo/routing/utils/__init__.py
@@ -1,4 +1,3 @@
 from maxo.routing.utils.collect_used_updates import collect_used_updates
-from maxo.routing.utils.is_async_callable import is_async_callable
 
-__all__ = ("collect_used_updates", "is_async_callable")
+__all__ = ("collect_used_updates",)

--- a/src/maxo/routing/utils/__init__.py
+++ b/src/maxo/routing/utils/__init__.py
@@ -1,3 +1,4 @@
 from maxo.routing.utils.collect_used_updates import collect_used_updates
+from maxo.routing.utils.is_async_callable import is_async_callable
 
-__all__ = ("collect_used_updates",)
+__all__ = ("collect_used_updates", "is_async_callable")

--- a/src/maxo/routing/utils/is_async_callable.py
+++ b/src/maxo/routing/utils/is_async_callable.py
@@ -1,0 +1,17 @@
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+def is_async_callable(obj: Callable[..., Any]) -> bool:
+    """
+    Проверяет, вернёт ли вызов объекта корутину.
+
+    В отличие от :func:`inspect.iscoroutinefunction` понимает экземпляры
+    классов с ``async def __call__``: сам объект корутинной функцией не
+    является, ей является его ``__call__``.
+    """
+    unwrapped = inspect.unwrap(obj)
+    return inspect.iscoroutinefunction(unwrapped) or (
+        callable(unwrapped) and inspect.iscoroutinefunction(type(unwrapped).__call__)
+    )

--- a/src/maxo/routing/utils/is_async_callable.py
+++ b/src/maxo/routing/utils/is_async_callable.py
@@ -13,5 +13,5 @@ def is_async_callable(obj: Callable[..., Any]) -> bool:
     """
     unwrapped = inspect.unwrap(obj)
     return inspect.iscoroutinefunction(unwrapped) or inspect.iscoroutinefunction(
-        type(unwrapped).__call__,
+        inspect.unwrap(type(unwrapped).__call__),
     )

--- a/src/maxo/routing/utils/is_async_callable.py
+++ b/src/maxo/routing/utils/is_async_callable.py
@@ -4,14 +4,9 @@ from typing import Any
 
 
 def is_async_callable(obj: Callable[..., Any]) -> bool:
-    """
-    Проверяет, вернёт ли вызов объекта корутину.
-
-    В отличие от :func:`inspect.iscoroutinefunction` понимает экземпляры
-    классов с ``async def __call__``: сам объект корутинной функцией не
-    является, ей является его ``__call__``.
-    """
     unwrapped = inspect.unwrap(obj)
-    return inspect.iscoroutinefunction(unwrapped) or inspect.iscoroutinefunction(
-        inspect.unwrap(type(unwrapped).__call__),
+    call = type(unwrapped).__call__
+    return any(
+        inspect.iscoroutinefunction(candidate)
+        for candidate in (obj, unwrapped, call, inspect.unwrap(call))
     )

--- a/src/maxo/routing/utils/is_async_callable.py
+++ b/src/maxo/routing/utils/is_async_callable.py
@@ -12,6 +12,6 @@ def is_async_callable(obj: Callable[..., Any]) -> bool:
     является, ей является его ``__call__``.
     """
     unwrapped = inspect.unwrap(obj)
-    return inspect.iscoroutinefunction(unwrapped) or (
-        callable(unwrapped) and inspect.iscoroutinefunction(type(unwrapped).__call__)
+    return inspect.iscoroutinefunction(unwrapped) or inspect.iscoroutinefunction(
+        type(unwrapped).__call__,
     )

--- a/tests/maxo/routing/test_class_based_handlers.py
+++ b/tests/maxo/routing/test_class_based_handlers.py
@@ -5,7 +5,6 @@ from maxo.enums import ChatType
 from maxo.routing.ctx import Ctx
 from maxo.routing.handlers.signal import SignalHandler
 from maxo.routing.handlers.update import UpdateHandler
-from maxo.routing.utils import is_async_callable
 from maxo.types import Message, MessageBody, MessageCreated, Recipient
 from tests.constants import NOW
 
@@ -28,14 +27,6 @@ class SyncCallableHandler:
         return "done"
 
 
-async def async_fn(update: Any, **kwargs: Any) -> str:
-    return "done"
-
-
-def sync_fn(update: Any, **kwargs: Any) -> str:
-    return "done"
-
-
 def decorator(fn: Any) -> Any:
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -55,12 +46,16 @@ def make_update() -> MessageCreated:
     )
 
 
-def test_is_async_callable() -> None:
-    assert is_async_callable(async_fn)
-    assert is_async_callable(AsyncCallableHandler())
-    assert is_async_callable(decorator(async_fn))
-    assert not is_async_callable(sync_fn)
-    assert not is_async_callable(SyncCallableHandler())
+async def handler_with_params(update: Any, bot: Any) -> Any:
+    return bot
+
+
+async def test_decorated_handler_receives_only_declared_params() -> None:
+    handler = UpdateHandler[MessageCreated, Any](decorator(handler_with_params))
+
+    ctx = Ctx({"update": make_update(), "bot": "bot", "extra": 1})
+
+    assert await handler(ctx) == "bot"
 
 
 async def test_class_based_update_handler_is_executed() -> None:

--- a/tests/maxo/routing/test_class_based_handlers.py
+++ b/tests/maxo/routing/test_class_based_handlers.py
@@ -86,3 +86,15 @@ async def test_class_based_signal_handler_is_executed() -> None:
     handler = SignalHandler[Any, str](handler_fn)
 
     assert await handler(Ctx({"update": None})) == "done"
+
+
+class DecoratedCallableHandler:
+    @decorator
+    async def __call__(self, update: Any, **kwargs: Any) -> str:
+        return "done"
+
+
+async def test_decorated_call_class_based_handler_is_executed() -> None:
+    handler = UpdateHandler[MessageCreated, str](DecoratedCallableHandler())
+
+    assert await handler(Ctx({"update": make_update()})) == "done"

--- a/tests/maxo/routing/test_class_based_handlers.py
+++ b/tests/maxo/routing/test_class_based_handlers.py
@@ -1,0 +1,93 @@
+import functools
+from typing import Any
+
+from maxo.enums import ChatType
+from maxo.routing.ctx import Ctx
+from maxo.routing.handlers.signal import SignalHandler
+from maxo.routing.handlers.update import UpdateHandler
+from maxo.routing.utils import is_async_callable
+from maxo.types import Message, MessageBody, MessageCreated, Recipient
+from tests.constants import NOW
+
+
+class AsyncCallableHandler:
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    async def __call__(self, update: Any, **kwargs: Any) -> str:
+        self.calls.append(update)
+        return "done"
+
+
+class SyncCallableHandler:
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def __call__(self, update: Any, **kwargs: Any) -> str:
+        self.calls.append(update)
+        return "done"
+
+
+async def async_fn(update: Any, **kwargs: Any) -> str:
+    return "done"
+
+
+def sync_fn(update: Any, **kwargs: Any) -> str:
+    return "done"
+
+
+def decorator(fn: Any) -> Any:
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def make_update() -> MessageCreated:
+    return MessageCreated(
+        message=Message(
+            body=MessageBody(mid="test", seq=1),
+            recipient=Recipient(chat_type=ChatType.DIALOG, chat_id=1),
+            timestamp=NOW,
+        ),
+        timestamp=NOW,
+    )
+
+
+def test_is_async_callable() -> None:
+    assert is_async_callable(async_fn)
+    assert is_async_callable(AsyncCallableHandler())
+    assert is_async_callable(decorator(async_fn))
+    assert not is_async_callable(sync_fn)
+    assert not is_async_callable(SyncCallableHandler())
+
+
+async def test_class_based_update_handler_is_executed() -> None:
+    handler_fn = AsyncCallableHandler()
+    handler = UpdateHandler[MessageCreated, str](handler_fn)
+    update = make_update()
+
+    result = await handler(Ctx({"update": update}))
+
+    assert result == "done"
+    assert handler_fn.calls == [update]
+
+
+async def test_sync_class_based_update_handler_is_executed() -> None:
+    handler_fn = SyncCallableHandler()
+    # синхронный вызываемый объект допустим в рантайме, но не по протоколу
+    handler = UpdateHandler[MessageCreated, str](handler_fn)  # type: ignore[arg-type]
+    update = make_update()
+
+    result = await handler(Ctx({"update": update}))
+
+    assert result == "done"
+    assert handler_fn.calls == [update]
+
+
+async def test_class_based_signal_handler_is_executed() -> None:
+    handler_fn = AsyncCallableHandler()
+    handler = SignalHandler[Any, str](handler_fn)
+
+    assert await handler(Ctx({"update": None})) == "done"

--- a/tests/maxo/routing/test_class_based_handlers.py
+++ b/tests/maxo/routing/test_class_based_handlers.py
@@ -98,3 +98,33 @@ async def test_decorated_call_class_based_handler_is_executed() -> None:
     handler = UpdateHandler[MessageCreated, str](DecoratedCallableHandler())
 
     assert await handler(Ctx({"update": make_update()})) == "done"
+
+
+def async_decorator(fn: Any) -> Any:
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def sync_handler(update: Any, **kwargs: Any) -> str:
+    return "done"
+
+
+class AsyncDecoratedCallableHandler:
+    @async_decorator
+    def __call__(self, update: Any, **kwargs: Any) -> str:
+        return "done"
+
+
+async def test_async_decorated_handler_is_awaited() -> None:
+    handler = UpdateHandler[MessageCreated, str](async_decorator(sync_handler))
+
+    assert await handler(Ctx({"update": make_update()})) == "done"
+
+
+async def test_async_decorated_call_handler_is_awaited() -> None:
+    handler = UpdateHandler[MessageCreated, str](AsyncDecoratedCallableHandler())
+
+    assert await handler(Ctx({"update": make_update()})) == "done"


### PR DESCRIPTION
# Описание

`UpdateHandler` и `SignalHandler` определяли асинхронность хендлера через `inspect.iscoroutinefunction(handler_fn)`. Для экземпляра класса с `async def __call__` эта проверка даёт `False`: она смотрит на сам объект, а не на его `__call__`. Хендлер уходил в ветку `asyncio.to_thread`, поток создавал корутину и возвращал её, `await` получал необработанный coroutine-объект. Тело хендлера не выполнялось, но возвращалось не-`UNHANDLED`, роутинг считал апдейт обработанным и не отдавал его дочерним роутерам. Апдейт терялся молча, единственный след - `RuntimeWarning: coroutine 'H.__call__' was never awaited`.

Детекция вынесена в `maxo/routing/utils/is_async_callable.py` и подставлена во все три места, куда эта проверка была скопирована:

- `src/maxo/routing/handlers/update.py:52`
- `src/maxo/routing/handlers/signal.py:47`
- `src/maxo/dialogs/widgets/filter_object.py:30` - тот же баг, из-за него молча не срабатывал класс-объект в `on_click` и `on_success` диалогов

Из условия убран `inspect.isawaitable(handler_fn)`. Функция никогда не бывает awaitable, awaitable - только уже созданная корутина, так что эта половина проверки была мёртвой.

## Второй баг, найденный по дороге

`inspect.getfullargspec` не идёт по `__wrapped__`, поэтому у хендлера под `functools.wraps`-декоратором argspec читался с обёртки:

```text
argspec(wrapper):          args=[],                varkw='kw'
argspec(unwrap(wrapper)):  args=['update', 'bot'], varkw=None
```

`varkw=True` означает "передать весь ctx", и декорированный хендлер без `**kwargs` падал с `TypeError: got an unexpected keyword argument 'extra'`. В обоих хендлерах добавлен `inspect.unwrap` перед `getfullargspec` - в `filter_object.py` так уже было сделано.

Closes #182

## Тип изменения

- [ ] Документация (опечатки, примеры кода или любые другие обновления документации)
- [x] Исправление бага (некритическое изменение, которое устраняет проблему)
- [ ] Новый функционал (некритическое изменение, добавляющее функциональность)
- [ ] Критические изменения (исправление или функционал, из-за которого существующая функциональность не будет работать должным образом)
- [ ] Это изменение требует обновления документации

# Как это было протестировано?

Новый файл `tests/maxo/routing/test_class_based_handlers.py`, 4 теста: async-класс через `UpdateHandler`, sync-класс (ветка `to_thread`), async-класс через `SignalHandler`, декорированный хендлер с лишними ключами в ctx. На коде до фикса три из них красные, с той самой `RuntimeWarning`.

Что тесты держат именно эти ветки, проверено мутациями хелпера, а не рассуждением:

| мутация `is_async_callable` | полный прогон |
|---|---|
| убрать проверку `__call__` (исходный баг) | 2 failed |
| `return True` | 4 failed |
| `return False` | 71 failed |
| убрать `inspect.unwrap` | 1 failed |

Команды:

- `uv run ruff check --no-fix .` - All checks passed
- `uv run mypy --config-file pyproject.toml` - no issues in 708 source files
- `uv run pytest tests/maxo/routing/test_class_based_handlers.py -q` - 4 passed
- `uv run pytest tests/ -q` - 1723 passed
- `just lint` - codespell, slotscheck, bandit чисто

Docs не трогал: класс-хендлеры в `docs/pages/event-handling/handlers.rst` не описаны, `__call__` там появляется только у фильтров и мидлварей. Фикс возвращает поведение, которое протокол `UpdateHandlerFn` и так обещал.

**Тестовая конфигурация**:
* Операционная система: macOS 15.7.7
* Версия Python: 3.12.7

# Контрольный список:

- [x] Мой код соответствует рекомендациям по стилю этого проекта
- [x] Я выполнил самопроверку своего кода
- [ ] Я внёс соответствующие изменения в документацию
- [x] Я добавил тесты, которые доказывают, что моё исправление эффективно или моя функция работает
- [x] Новые и существующие модульные тесты проходят локально с моими изменениями
- [ ] Код полностью написан мной без использования нейросетей
- [x] Код частично или полностью написан нейросетями, но прошёл полный контроль со стороны человека


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Повышена точность распознавания асинхронных обработчиков, включая обработчики на основе классов.
  * Улучшен анализ обработчиков, обёрнутых декораторами.
  * Повышена стабильность выполнения синхронных и асинхронных обработчиков событий и обновлений.

* **Тесты**
  * Добавлены проверки для классов-обработчиков, декорированных функций и корректной передачи параметров.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->